### PR TITLE
feat(thermo) Phase 2: flexible buffer (solvents/ions), unify screen buffers (P5), DNA physics for orthogonality (R5/P3)

### DIFF
--- a/docs/thermodynamics_parameters.md
+++ b/docs/thermodynamics_parameters.md
@@ -88,11 +88,18 @@ Thermo 5× RT buffer: 250 mM Tris-HCl (pH 8.3), 375 mM KCl, 15 mM MgCl₂, 50 mM
 (<https://assets.thermofisher.com/TFS-Assets/LSG/manuals/MAN0012047_TS_Maxima_H_Minus_Reverse_Transcriptase_2000U_UG.pdf>).
 Tris (~50 mM at 1×, ~+25 mM Na-equiv) omitted as a minor term.
 
-### 4c. Cross-ligation / NUPACK screens (unchanged; to be unified — Phase 2)
+### 4c. Cross-ligation / NUPACK / orthogonality screens (unified 2026-07-20)
 
-`qc/cross_ligation.py` and `ext/nupack/config.py` independently encode the same
-2026-05-26 lab buffer (75 mM monovalent, 10 mM Mg²⁺, 0.1 µM, 55 °C
-formamide-effective). Phase 2 will point these at `ReactionConditions`.
+`qc/cross_ligation.py` and `ext/nupack/config.py` previously each hard-coded the
+lab buffer; both now **derive** their constants from the shared
+`ReactionConditions` defaults, so the screens and the Tm path cannot drift apart
+(values unchanged: 75 mM monovalent, 10 mM Mg²⁺, 0.1 µM, 55 °C formamide-effective).
+
+`filtering/pairwise_duplex.py` (panel orthogonality) previously scored
+padlock–padlock **DNA:DNA** dimers with ViennaRNA's **RNA** Turner parameters;
+it now uses **primer3** (SantaLucia unified DNA NN) at the same buffer. ΔG
+magnitudes are therefore not comparable to pre-2026-07-20 values; the −12 kcal/mol
+default is a permissive log-only threshold, re-tune before using it to drop probes.
 
 ## 5. Tm window anchoring
 

--- a/docs/thermodynamics_parameters.md
+++ b/docs/thermodynamics_parameters.md
@@ -35,16 +35,29 @@ error) is the modern set; see the audit for the upgrade plan.
 | Salt-correction method | `saltcorr = 5` | `chemistry.ReactionConditions.saltcorr` → `tm_nn_kwargs()` | **SantaLucia 1998** entropic correction (Biopython method 5), with the **von Ahsen et al. 2001** (*Clin Chem* 47:1956) Mg²⁺→Na⁺-equivalent conversion applied automatically when Mg≠0 (Biopython `MeltingTemp.salt_correction:534`). Recommended combination per **von Ahsen, Wittwer & Schütz 2011**, *Brief Bioinform* 12:514. |
 | Alternative (high Mg) | `saltcorr = 7` | same | **Owczarzy et al. 2008**, *Biochemistry* 47:5336 (divalent decision tree). Slightly more conservative at ≥8 mM Mg²⁺; user-selectable. |
 
-## 3. Formamide correction
+## 3. Co-solvent correction (flexible)
 
-| Parameter | Value | Set at | Source |
-|---|---|---|---|
-| Model | linear (`chem_correction`, `fmdmethod=1`): `Tm -= factor × %formamide` | `ReactionConditions.apply_formamide` | **McConaughy et al. 1969**, *Biochemistry* 8:3289 (via Biopython `chem_correction`). |
-| Coefficient | `formamide_deg_per_pct = 0.5` °C/% | `ReactionConditions` | Chosen to **match the existing cross-lig / NUPACK screen model** (`qc/cross_ligation.py`, `ext/nupack/config.py` both used 0.5 °C/%). Literature range is 0.6–0.72 (Biopython default 0.65); 0.5 is on the conservative end. **Tunable** — revisit if calibration data warrants. |
+Co-solvents depress Tm ~linearly (`Tm -= Σ coeff × %`). Formamide has a dedicated
+field; any other solvent goes in `ReactionConditions.solvents` keyed to the
+`SOLVENT_TM_COEFF` registry (`register_solvent(name, coeff)` adds one).
 
-The same coefficient drives the ΔG-screen effective temperature
-(`effective_celsius = lab_temp_c + formamide_pct × formamide_deg_per_pct`), so
-the Tm-domain and ΔG-domain treatments stay numerically consistent.
+| Solvent | Coefficient (°C/%) | Source |
+|---|---|---|
+| Formamide | `formamide_deg_per_pct = 0.5` | **McConaughy 1969** (via Biopython `chem_correction`). Matches the cross-lig/NUPACK screens (both 0.5); literature 0.6–0.72, Biopython default 0.65 — 0.5 is conservative, **tunable**. |
+| DMSO | `SOLVENT_TM_COEFF["dmso"] = 0.6` | **von Ahsen 2001** (typical 0.5–0.75). |
+| other (betaine, glycol, …) | user-supplied via `register_solvent` | No built-in NN term — supply a **lab-calibrated** coefficient (approximate). |
+
+`ReactionConditions.solvent_tm_depression` sums these; the same value drives the
+ΔG-screen effective temperature (`effective_celsius = lab_temp_c + depression`),
+keeping the Tm-domain and ΔG-domain treatments consistent.
+
+**Flexibility & its limit.** Tm-from-buffer is only as flexible as the correction
+*physics*: monovalent cations (Na/K/Tris) are **equivalent** for Tm (ionic
+strength) — set the total `monovalent_mM` or use `ReactionConditions.from_buffer(
+na_mM=, k_mM=, tris_mM=)`; **Mg²⁺ is the only modelled divalent** (approximate a
+novel divalent as Mg²⁺-equivalent); solvents beyond formamide/DMSO need an
+empirical coefficient. A component with no physical model **fails fast** rather
+than silently returning a wrong Tm.
 
 ## 4. Reaction buffers
 

--- a/probe_designer/chemistry.py
+++ b/probe_designer/chemistry.py
@@ -32,7 +32,9 @@ from Bio.SeqUtils import MeltingTemp as mt
 # Valid Biopython MeltingTemp salt-correction methods (see salt_correction).
 _VALID_SALTCORR = frozenset({1, 2, 3, 4, 5, 6, 7})
 
-_COMPLEMENT = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N"}
+_COMPLEMENT = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N",
+               "U": "A",   # accept RNA input
+               "-": "-"}   # preserve gaps in aligned sequences
 
 # Tm depression coefficient (degC per % v/v) for co-solvents / denaturants.
 # Formamide keeps a dedicated field (historical + default); ANY other solvent
@@ -58,23 +60,45 @@ def register_solvent(name: str, deg_per_pct: float) -> None:
     SOLVENT_TM_COEFF[name.strip().lower()] = float(deg_per_pct)
 
 
-def dna_revcomp_to_rna(seq: str) -> str:
-    """Return the reverse complement of a DNA arm as the RNA-sense strand.
+def reverse_complement(seq: str) -> str:
+    """Reverse complement, uppercase. The canonical implementation for this package.
 
-    For a DNA probe arm hybridizing to mRNA, the reverse complement is the
-    target (mRNA) sequence. Biopython's ``R_DNA_NN1`` table *requires* the RNA
-    strand ("Note that ``seq`` must be the RNA sequence"), so this is the string
-    that must be fed to ``Tm_NN`` for a DNA:RNA hybrid. Thymine is intentionally
-    kept (the table is keyed on T), so the name means "RNA-sense", not literally
-    U-containing.
+    ``U`` reads as ``T`` (RNA input is accepted), a gap ``-`` is preserved so
+    aligned sequences survive the round trip, and anything else maps to ``N``
+    rather than raising — callers here feed validated ACGT, and a permissive
+    mapping keeps a batch of thousands from dying on one stray character.
+
+    This replaced seven near-identical private copies scattered across the
+    package, which had quietly diverged on three axes: whether the input was
+    uppercased first, whether an unknown base raised ``KeyError`` or became
+    ``N``, and whether ``-`` and ``U`` were handled at all. Divergence on the
+    case axis in particular meant the same call was safe in one module and a
+    crash in another.
 
     Args:
-        seq: DNA arm sequence, 5'->3' (case-insensitive).
+        seq: nucleotide sequence, 5'->3' (case-insensitive).
 
     Returns:
-        The reverse complement (unknown bases mapped to ``N``), uppercase.
+        The reverse complement, uppercase.
     """
     return "".join(_COMPLEMENT.get(base, "N") for base in reversed(seq.upper()))
+
+
+def dna_revcomp_to_rna(seq: str) -> str:
+    """The reverse complement of a DNA arm, named for its RNA-sense intent.
+
+    For a DNA probe arm hybridizing to mRNA, the reverse complement *is* the
+    target (mRNA) sequence. Biopython's ``R_DNA_NN1`` table requires the RNA
+    strand ("Note that ``seq`` must be the RNA sequence"), so this is the string
+    that must be fed to ``Tm_NN`` for a DNA:RNA hybrid. Thymine is intentionally
+    kept (the table is keyed on T), so "RNA-sense" here does not mean
+    U-containing.
+
+    Mechanically identical to :func:`reverse_complement`; kept as a separate
+    name because at the call sites the intent — "make the Tm table's required
+    strand" — is what needs to be readable.
+    """
+    return reverse_complement(seq)
 
 
 @dataclass

--- a/probe_designer/chemistry.py
+++ b/probe_designer/chemistry.py
@@ -10,14 +10,22 @@ and NUPACK buffers share a single source of truth.
 
 Defaults follow the current canonical protocol (spatial-workshop
 ``docs/protocols/rca.md`` v5.3): Ampligase 1x (25 mM K+, 10 mM Mg2+) + 50 mM
-added KCl + 20% formamide, annealed at 45 C. Formamide is modelled with a single
-coefficient (``formamide_deg_per_pct``) used both to depress arm Tm (Biopython
-``chem_correction``) and to raise the effective screen temperature — keeping the
-Tm-domain and ΔG-domain treatments numerically consistent.
+added KCl + 20% formamide, annealed at 45 C.
+
+Flexibility & its limits: Tm-from-buffer is only as flexible as the correction
+*physics*. Monovalent cations (Na/K/Tris) are equivalent for Tm (ionic strength)
+— pass the total via ``monovalent_mM`` or the granular ``from_buffer`` helper.
+Mg2+ is the only modelled divalent; approximate a novel divalent as Mg2+-equiv.
+Co-solvents depress Tm linearly: formamide has a dedicated field, any other
+solvent goes in ``solvents`` keyed to ``SOLVENT_TM_COEFF`` (``register_solvent``
+adds an empirical coefficient for a denaturant with no built-in NN term). The
+same solvent depression raises the effective screen temperature, keeping the
+Tm-domain and ΔG-domain treatments consistent.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict
 
 from Bio.SeqUtils import MeltingTemp as mt
 
@@ -25,6 +33,29 @@ from Bio.SeqUtils import MeltingTemp as mt
 _VALID_SALTCORR = frozenset({1, 2, 3, 4, 5, 6, 7})
 
 _COMPLEMENT = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N"}
+
+# Tm depression coefficient (degC per % v/v) for co-solvents / denaturants.
+# Formamide keeps a dedicated field (historical + default); ANY other solvent
+# goes in ReactionConditions.solvents keyed here. This is the extension point
+# for a denaturant Biopython doesn't build in (Tm-from-buffer is only as flexible
+# as the correction physics — beyond salt/formamide/DMSO there is no NN model, so
+# a novel solvent needs an empirical coefficient supplied here). Values are
+# midpoints of the literature range; override per lab as needed.
+SOLVENT_TM_COEFF: Dict[str, float] = {
+    "formamide": 0.5,   # McConaughy 1969 (repo-consistent; literature 0.6-0.72)
+    "dmso": 0.6,        # von Ahsen 2001 (typical 0.5-0.75)
+}
+
+
+def register_solvent(name: str, deg_per_pct: float) -> None:
+    """Register/override a co-solvent's Tm depression coefficient (degC per %).
+
+    Model a denaturant not built into the NN corrections (e.g. betaine,
+    ethylene glycol) by supplying an empirical coefficient, then list it in a
+    ReactionConditions ``solvents`` mapping. This is an approximation — there is
+    no first-principles NN term for it — so use a lab-calibrated value.
+    """
+    SOLVENT_TM_COEFF[name.strip().lower()] = float(deg_per_pct)
 
 
 def dna_revcomp_to_rna(seq: str) -> str:
@@ -63,6 +94,12 @@ class ReactionConditions:
         formamide_pct: Formamide (% v/v); destabilizes duplexes.
         formamide_deg_per_pct: Tm depression per % formamide (C/%). Also the
             effective-temperature offset coefficient for the ΔG screens.
+        solvents: Extra co-solvents beyond formamide, ``{name: % v/v}`` — each
+            depresses Tm by ``SOLVENT_TM_COEFF[name] * %`` (register_solvent to
+            add a coefficient). Novel divalent ions have no NN model; approximate
+            as Mg2+-equivalent via ``mg_mM``. Monovalents (Na/K/Tris) are
+            equivalent for Tm — pass the total via ``monovalent_mM`` or the
+            granular ``from_buffer(na_mM=, k_mM=, tris_mM=)`` helper.
         lab_temp_c: Hybridization anneal temperature (C); the arm-Tm anchor.
         tm_margin_c: Required arm-Tm margin above ``lab_temp_c`` (Krzywkowski 2017).
         saltcorr: Biopython MeltingTemp salt-correction method (1-7). 5 =
@@ -76,9 +113,22 @@ class ReactionConditions:
     strand_nM: float = 100.0
     formamide_pct: float = 20.0
     formamide_deg_per_pct: float = 0.5
+    solvents: Dict[str, float] = field(default_factory=dict)
     lab_temp_c: float = 45.0
     tm_margin_c: float = 5.0
     saltcorr: int = 5
+
+    @classmethod
+    def from_buffer(
+        cls, *, na_mM: float = 0.0, k_mM: float = 0.0, tris_mM: float = 0.0, **kwargs
+    ) -> "ReactionConditions":
+        """Build from granular monovalent cations (Na/K/Tris).
+
+        Monovalents are equivalent for Tm (the salt correction sees only the
+        total ionic strength), so they are folded into ``monovalent_mM`` as
+        ``Na + K + Tris/2`` (von Ahsen convention). All other fields pass through.
+        """
+        return cls(monovalent_mM=na_mM + k_mM + tris_mM / 2.0, **kwargs)
 
     def __post_init__(self) -> None:
         """Validate the composition, failing fast with an actionable message."""
@@ -97,6 +147,9 @@ class ReactionConditions:
             raise ValueError(
                 f"saltcorr must be one of {sorted(_VALID_SALTCORR)}, got {self.saltcorr}"
             )
+        for name, pct in self.solvents.items():
+            if pct < 0:
+                raise ValueError(f"solvent {name!r} percent must be >= 0, got {pct}")
 
     @property
     def min_arm_tm(self) -> float:
@@ -104,14 +157,32 @@ class ReactionConditions:
         return self.lab_temp_c + self.tm_margin_c
 
     @property
-    def effective_celsius(self) -> float:
-        """Formamide-shifted temperature for the ΔG/complex screens (C).
+    def solvent_tm_depression(self) -> float:
+        """Total Tm depression from all co-solvents (C): formamide + solvents.
 
-        Formamide is modelled as a temperature increase for the two-strand
-        screens (raising stringency), equivalent to the Tm depression applied to
-        arm Tm — both use ``formamide_deg_per_pct``.
+        Raises if a listed solvent has no coefficient (register_solvent first) —
+        Tm-from-buffer is only as flexible as the correction physics.
         """
-        return self.lab_temp_c + self.formamide_pct * self.formamide_deg_per_pct
+        dep = self.formamide_pct * self.formamide_deg_per_pct
+        for name, pct in self.solvents.items():
+            key = name.strip().lower()
+            if key not in SOLVENT_TM_COEFF:
+                raise ValueError(
+                    f"unknown solvent {name!r}; call register_solvent(name, "
+                    "deg_per_pct) with an empirical coefficient first"
+                )
+            dep += SOLVENT_TM_COEFF[key] * pct
+        return dep
+
+    @property
+    def effective_celsius(self) -> float:
+        """Solvent-shifted temperature for the ΔG/complex screens (C).
+
+        Co-solvents are modelled as a temperature increase for the two-strand
+        screens (raising stringency), equal to the Tm depression applied to arm
+        Tm — both use ``solvent_tm_depression``.
+        """
+        return self.lab_temp_c + self.solvent_tm_depression
 
     def tm_nn_kwargs(self) -> dict:
         """Keyword arguments for ``Bio.SeqUtils.MeltingTemp.Tm_NN``.
@@ -131,15 +202,16 @@ class ReactionConditions:
             "saltcorr": self.saltcorr,
         }
 
-    def apply_formamide(self, tm: float) -> float:
-        """Depress a computed Tm for formamide (Biopython ``chem_correction``).
+    def apply_solvents(self, tm: float) -> float:
+        """Depress a computed Tm for all co-solvents (formamide + ``solvents``).
 
-        Uses ``fmdmethod=1`` (linear, ``Tm -= factor * %formamide``) with the
-        object's ``formamide_deg_per_pct`` as the factor.
+        Linear per solvent (McConaughy ``fmdmethod=1``): ``Tm -= sum(coeff * %)``,
+        matching Biopython ``chem_correction`` for the formamide term.
         """
-        return mt.chem_correction(
-            tm, fmd=self.formamide_pct, fmdfactor=self.formamide_deg_per_pct
-        )
+        return tm - self.solvent_tm_depression
+
+    # Backward-compat alias (pre-2026-07-20 name; formamide was the only solvent).
+    apply_formamide = apply_solvents
 
     def primer3_kwargs(self) -> dict:
         """Buffer kwargs for primer3 ``calc_heterodimer`` / ``calc_tm``.
@@ -171,8 +243,11 @@ class ReactionConditions:
         (see filtering.thermo_profile). Excludes ``lab_temp_c`` / ``tm_margin_c``
         (they set the gate/target, not the Tm value itself).
         """
+        sv = "".join(
+            f"-{n}{p:g}" for n, p in sorted(self.solvents.items())
+        )
         return (
             f"mv{self.monovalent_mM:g}_mg{self.mg_mM:g}_dn{self.dntp_mM:g}"
             f"_st{self.strand_nM:g}_fa{self.formamide_pct:g}"
-            f"_fd{self.formamide_deg_per_pct:g}_sc{self.saltcorr}"
+            f"_fd{self.formamide_deg_per_pct:g}_sc{self.saltcorr}{sv}"
         )

--- a/probe_designer/config/__init__.py
+++ b/probe_designer/config/__init__.py
@@ -5,7 +5,7 @@ Manages all configurable parameters for DNA probe design.
 
 import os
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
 import json
 import yaml
@@ -97,6 +97,7 @@ class FilterConfig:
     strand_nM: float = 100.0           # 0.1 µM probe
     formamide_pct: float = 20.0        # % formamide (depresses Tm)
     formamide_deg_per_pct: float = 0.5  # °C Tm depression per % formamide
+    solvents: Dict[str, float] = field(default_factory=dict)  # extra co-solvents {name: %}; see chemistry.SOLVENT_TM_COEFF
     lab_temp_c: float = 45.0           # hyb anneal temperature; arm-Tm anchor
     tm_margin_c: float = 5.0           # min arm Tm = lab_temp_c + tm_margin_c
     saltcorr: int = 5                  # Biopython salt method (5 = SantaLucia'98 + von Ahsen Mg)
@@ -118,6 +119,7 @@ class FilterConfig:
             strand_nM=self.strand_nM,
             formamide_pct=self.formamide_pct,
             formamide_deg_per_pct=self.formamide_deg_per_pct,
+            solvents=dict(self.solvents),
             lab_temp_c=self.lab_temp_c,
             tm_margin_c=self.tm_margin_c,
             saltcorr=self.saltcorr,
@@ -393,6 +395,7 @@ class ConfigManager:
                 'strand_nM': self.filter.strand_nM,
                 'formamide_pct': self.filter.formamide_pct,
                 'formamide_deg_per_pct': self.filter.formamide_deg_per_pct,
+                'solvents': dict(self.filter.solvents),
                 'lab_temp_c': self.filter.lab_temp_c,
                 'tm_margin_c': self.filter.tm_margin_c,
                 'saltcorr': self.filter.saltcorr,

--- a/probe_designer/database.py
+++ b/probe_designer/database.py
@@ -55,7 +55,16 @@ class DatabaseInterface:
         return fetch
     
     def local_genome_accessor(self, genome_fasta_path: str):
-        """Create local FASTA genome accessor function using pyfaidx."""
+        """Create local FASTA genome accessor function using pyfaidx.
+
+        NOTE: ``probe_designer.genome.local_fasta.build_genome_accessor`` does
+        the same job and additionally reconciles the chr-prefix mismatch (Ensembl
+        reports ``seq_region_name`` as ``10`` while many FASTAs key on ``chr10``),
+        so this accessor raises ``KeyError`` on inputs the other one handles. They
+        differ on failure too — that one returns ``""`` so a batch keeps running,
+        this one raises. Worth unifying, but the failure-mode change needs its own
+        review; not folded into the reverse_complement consolidation.
+        """
         try:
             from pyfaidx import Fasta
             genome = Fasta(genome_fasta_path)
@@ -64,7 +73,13 @@ class DatabaseInterface:
                 chrom = str(seq_region_name)
                 if chrom not in genome:
                     raise KeyError(f"Chromosome {chrom} not found in FASTA file")
-                seq = genome[chrom][start-1:end]  # pyfaidx uses 0-based coordinates
+                # Contract: start/end are 1-based inclusive (Ensembl convention).
+                # The -1 converts to pyfaidx's 0-based half-open slice. The old
+                # comment here read "pyfaidx uses 0-based coordinates", which
+                # described pyfaidx's internals but was routinely misread as this
+                # function's parameter convention — the opposite. Coordinate
+                # semantics get stated from the caller's side now.
+                seq = genome[chrom][start - 1:end]
                 return str(seq)
             
             return fetch
@@ -539,8 +554,3 @@ class SequenceProcessor:
             gene_info['seq'] = str(coding_sequence)
         return gene_info['seq'], gene_info
     
-    @staticmethod
-    def reverse_complement(sequence: str) -> str:
-        """Return reverse complement of a DNA sequence."""
-        complement = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N"}
-        return "".join(complement[base] for base in reversed(sequence))

--- a/probe_designer/ext/mutation/probe.py
+++ b/probe_designer/ext/mutation/probe.py
@@ -19,6 +19,7 @@ import logging
 from tqdm import tqdm
 from copy import deepcopy
 
+from probe_designer.chemistry import reverse_complement
 from probe_designer.config import SearchConfig, FilterConfig, BlastConfig
 from probe_designer.filtering import SequenceFilter
 
@@ -108,10 +109,6 @@ class MutationProbeDesigner:
             
         return pos5_local
     
-    def _reverse_complement(self, sequence: str) -> str:
-        """Return reverse complement of a DNA sequence."""
-        complement = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N"}
-        return "".join(complement[base] for base in reversed(sequence))
     
     def _mutate_genomic_sequence(self, genomic_seq: str, mut_start: int, mut_end: int, 
                                 ref: str, alt: str, strand: int) -> Tuple[str, int, int]:
@@ -197,7 +194,7 @@ class MutationProbeDesigner:
             pos3_target = pos5_local + 1 # pos3 equals pos5 for Python coordinates (left-closed, right-open)
         else:  # strand == -1
             # For negative strand, convert plus_seq to mRNA (reverse complement)
-            target_seq = self._reverse_complement(plus_seq)
+            target_seq = reverse_complement(plus_seq)
             # Convert coordinates: for negative strand, we need to reverse the positions
             # pos5_local in plus_seq corresponds to len(plus_seq) - 1 - pos5_local in target_seq
             pos5_target = len(plus_seq) - 1 - pos5_local
@@ -210,8 +207,8 @@ class MutationProbeDesigner:
         # Step 3: Generate padlock arms based on target type
         if self.target_type == "RNA":
             # mRNA targeting: padlock arms = RC(mRNA region)
-            probe_arm5 = self._reverse_complement(arm5_seq)
-            probe_arm3 = self._reverse_complement(arm3_seq)
+            probe_arm5 = reverse_complement(arm5_seq)
+            probe_arm3 = reverse_complement(arm3_seq)
         else:
             # cDNA targeting: cDNA = RC(mRNA), so padlock arms = mRNA sequence
             # Arms are swapped because cDNA runs antiparallel to mRNA
@@ -225,7 +222,7 @@ class MutationProbeDesigner:
         if self.target_type == "RNA":
             target_sequence = arm5_seq + arm3_seq  # mRNA sequence
         else:
-            target_sequence = self._reverse_complement(arm5_seq + arm3_seq)  # cDNA sequence
+            target_sequence = reverse_complement(arm5_seq + arm3_seq)  # cDNA sequence
 
         return {
             'probe_arm5': probe_arm5,  # Padlock 5' arm
@@ -537,7 +534,7 @@ class MutationProbeDesignerInvader(MutationProbeDesigner):
             target_seq = plus_seq
             pos5_target = pos5_local
         else:
-            target_seq = self._reverse_complement(plus_seq)
+            target_seq = reverse_complement(plus_seq)
             pos5_target = len(plus_seq) - 1 - pos5_local
         # KEY DIFFERENCE vs parent: arm3 starts AT pos5 (overlap by 1 nt at SNP)
         # rather than at pos5+1. Both arms include the SNP at their adjacent end.
@@ -546,8 +543,8 @@ class MutationProbeDesignerInvader(MutationProbeDesigner):
         arm5_seq = target_seq[pos5_target + 1 - arm5_len : pos5_target + 1]
         arm3_seq = target_seq[pos3_target : pos3_target + arm3_len]
 
-        probe_arm5 = self._reverse_complement(arm5_seq)
-        probe_arm3 = self._reverse_complement(arm3_seq)
+        probe_arm5 = reverse_complement(arm5_seq)
+        probe_arm3 = reverse_complement(arm3_seq)
 
         # Continuous mRNA region, deduplicated (the SNP nt at arm5_seq[-1] ==
         # arm3_seq[0] is shared on the target).

--- a/probe_designer/ext/nupack/config.py
+++ b/probe_designer/ext/nupack/config.py
@@ -16,30 +16,36 @@ destabilization as an effective ``celsius``.
 """
 from __future__ import annotations
 
+from probe_designer.chemistry import ReactionConditions
 
-# Monovalent salt (K+ from Ampligase + extra KCl) — passed as 'sodium' to NUPACK Model
-# (NN model treats Na+ and K+ as equivalent monovalents).
-DEFAULT_SODIUM_M: float = 0.075
+# Single source of truth for the lab buffer: the shared ReactionConditions
+# defaults (protocol rca.md v5.3). These screen constants are DERIVED from it so
+# the cross-lig / NUPACK screens and the Tm path never drift apart (audit P5).
+_LAB = ReactionConditions()
+_NK = _LAB.nupack_kwargs()
 
-# Divalent (Mg2+) from Ampligase buffer
-DEFAULT_MAGNESIUM_M: float = 0.010
+# Monovalent salt (K+) — passed as 'sodium' to NUPACK (NN treats Na+/K+ alike).
+DEFAULT_SODIUM_M: float = _NK["sodium"]
 
-# Effective temperature in no-formamide NN model: 45 °C lab + 10 °C formamide shift
-DEFAULT_CELSIUS: float = 55.0
+# Divalent (Mg2+) from Ampligase buffer.
+DEFAULT_MAGNESIUM_M: float = _NK["magnesium"]
 
-# Informational only — not passed to NUPACK
-DEFAULT_LAB_TEMP_C: float = 45.0
-DEFAULT_FORMAMIDE_PCT: float = 20.0
-DEFAULT_FORMAMIDE_DEG_PER_PCT: float = 0.5
+# Effective temperature in the no-formamide NN model (lab temp + formamide shift).
+DEFAULT_CELSIUS: float = _NK["celsius"]
+
+# Informational only — not passed to NUPACK.
+DEFAULT_LAB_TEMP_C: float = _LAB.lab_temp_c
+DEFAULT_FORMAMIDE_PCT: float = _LAB.formamide_pct
+DEFAULT_FORMAMIDE_DEG_PER_PCT: float = _LAB.formamide_deg_per_pct
 
 # NUPACK ensemble — 'stacking' = coaxial stacking on (DEFAULT, the whole point
 # of using NUPACK over primer3 for nick-junction energetics).
 # 'nostacking' = ablation test; produces less-stable ternary ΔG.
 DEFAULT_ENSEMBLE: str = "stacking"
 
-# Probe strand concentration (each of arm3, arm5, splint).
+# Probe strand concentration (each of arm3, arm5, splint), from the shared buffer.
 # 0.1 μM is the midpoint of the panel-dependent range 0.05–0.2 μM.
-DEFAULT_STRAND_CONC_M: float = 1.0e-7
+DEFAULT_STRAND_CONC_M: float = _LAB.strand_nM * 1e-9
 
 # Productive ternary complex fraction threshold:
 # [arm3·splint·arm5] / [splint]_total > threshold flags as cross-lig risk.

--- a/probe_designer/ext/tcr/probe.py
+++ b/probe_designer/ext/tcr/probe.py
@@ -15,7 +15,11 @@ from typing import Any, Dict, List, Optional
 
 from Bio.SeqUtils import MeltingTemp as mt
 
-from probe_designer.chemistry import ReactionConditions, dna_revcomp_to_rna
+from probe_designer.chemistry import (
+    ReactionConditions,
+    dna_revcomp_to_rna,
+    reverse_complement,
+)
 
 try:
     import RNA  # ViennaRNA bindings — provides MFE via RNA.fold
@@ -24,10 +28,9 @@ except ImportError:
     _HAS_VIENNARNA = False
 
 
-def _reverse_complement(seq: str) -> str:
-    """Return the reverse complement of a DNA sequence."""
-    comp = {"A": "T", "T": "A", "C": "G", "G": "C", "-": "-", "N": "N"}
-    return "".join(comp[b] for b in reversed(seq.upper()))
+# Gap-preserving: aligned clone sequences carry '-', which the canonical
+# implementation passes through unchanged.
+_reverse_complement = reverse_complement
 
 
 def validate_subseq_in_target(target_seq: str, allowed_subseq: str) -> int:

--- a/probe_designer/filtering/pairwise_duplex.py
+++ b/probe_designer/filtering/pairwise_duplex.py
@@ -1,34 +1,26 @@
-"""Pairwise heteroduplex prediction via ViennaRNA RNAduplex.
+"""Pairwise heteroduplex prediction via primer3 (DNA nearest-neighbor).
 
-Phase 1B (2026-05-14) ships the shared backend used by:
+Used by the **orthogonality screen** — flags any pair of probes in the same
+panel whose duplex ΔG sits below a permissive threshold. Action is *log only*:
+the panel manifest grows a warnings TSV, but probes are not auto-dropped.
 
-* the **orthogonality consumer** — flags any pair of probes in the same
-  panel whose duplex ΔG sits below a permissive threshold (~−12 kcal/mol).
-  Action is *log only*: the panel manifest grows a warnings TSV, but
-  probes are not auto-dropped.
-* the Phase 2D **cross-ligation screen** — runs only on pairs already
-  flagged by a fast k-mer junction-spanning seed; uses a tighter ΔG cut
-  (~−10 kcal/mol) and a junction-span policy on top of the same backend.
+**2026-07-20 (audit R5/P3): switched from ViennaRNA ``duplexfold`` to primer3.**
+Padlock–padlock dimers are DNA:DNA, but ViennaRNA has no first-class DNA
+parameter set, so the previous implementation scored them with RNA (Turner)
+energies — the wrong physics, which also made the ΔG cutoffs rest on RNA
+energetics. primer3 uses the SantaLucia unified DNA nearest-neighbor model and
+takes the real buffer (monovalent / Mg2+ / dNTP / strand conc / temperature)
+from a :class:`~probe_designer.chemistry.ReactionConditions`, so this screen now
+shares the same physics and buffer as the cross-ligation screen.
 
-The wrapper is intentionally thin around ``RNA.duplexfold`` because:
+Note on thresholds: ΔG magnitudes are NOT comparable to the old RNA-parameter
+values. ``DEFAULT_DG_THRESHOLD`` is kept at the historical −12 kcal/mol as a
+permissive log-only default; re-tune against a real panel if it is ever used to
+drop probes.
 
-1. ``duplexfold`` returns the *optimal* duplex of two strands (single best
-   alignment). For the panel-level screens this is sufficient — we are
-   looking for the strongest unintended pairing, not enumerating all
-   sub-optimal hits.
-2. ViennaRNA's dot-bracket already encodes the alignment span on each
-   strand; the parser below converts it to 0-indexed half-open Python
-   ranges.
-
-Temperature plumbing follows the Phase 1A convention: pass
-``temperature`` (°C) and the global ``RNA.cvar.temperature`` is set
-before calling duplexfold. Raise to 47–55 °C to mimic ~20% formamide
-destabilization in our hybridization buffer.
-
-This module does NOT model multi-strand competition. For ensemble
-analysis (concentration-aware competition, useful when one probe could
-pair with multiple others), use the NUPACK wrapper in Phase 2D's
-``pool/ensemble.py``.
+This module does NOT model multi-strand competition. For concentration-aware
+ensemble analysis (one probe competing across many partners) use the NUPACK
+wrapper in ``ext/nupack``.
 """
 from __future__ import annotations
 
@@ -36,19 +28,14 @@ import logging
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from itertools import combinations
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
-try:
-    import RNA  # ViennaRNA bindings (>= 2.7.0)
-    _HAS_VIENNARNA = True
-except ImportError:
-    _HAS_VIENNARNA = False
+from probe_designer.chemistry import ReactionConditions
 
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_DG_THRESHOLD = -12.0  # kcal/mol — orthogonality default
-DEFAULT_TEMPERATURE = 37.0
+DEFAULT_DG_THRESHOLD = -12.0  # kcal/mol — orthogonality default (log-only)
 
 
 @dataclass(frozen=True)
@@ -59,9 +46,9 @@ class DuplexHit:
         probe_a_id: identifier for strand A.
         probe_b_id: identifier for strand B.
         delta_g: ΔG of the optimal duplex (kcal/mol; negative = stable).
-        structure: ViennaRNA dot-bracket; ``&`` separates the two strands.
+        structure: primer3 4-line ASCII dimer structure.
         span_a: 0-indexed half-open ``(start, end)`` range on strand A that
-            participates in the duplex.
+            participates in the duplex (from the parsed base pairing).
         span_b: 0-indexed half-open ``(start, end)`` range on strand B.
     """
     probe_a_id: str
@@ -72,35 +59,21 @@ class DuplexHit:
     span_b: Tuple[int, int]
 
 
-def _parse_duplex_spans(
-    structure: str, i: int, j: int,
-) -> Tuple[Tuple[int, int], Tuple[int, int]]:
-    """Convert ViennaRNA's ``structure`` + ``i`` + ``j`` to 0-indexed spans.
+def _spans_from_ascii(ascii_structure: str) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Half-open paired spans on A and B from a primer3 ASCII dimer structure.
 
-    The structure looks like ``"(((((((&)))))))"`` where ``&`` separates
-    strand A (left) and strand B (right). ViennaRNA reports:
-
-    * ``i`` — 1-indexed END position on strand A (last base of left side
-      structure).
-    * ``j`` — 1-indexed START position on strand B (first base of right
-      side structure).
-
-    Returns half-open Python ranges so they slice directly:
-    ``probe_a[span_a[0]:span_a[1]]`` is the duplex region on A.
+    Returns ``((0, 0), (0, 0))`` when no base pairs are present (or the ASCII is
+    unparseable) — the parser degrades gracefully rather than raising.
     """
-    if "&" not in structure:
-        # Defensive: should never happen for duplexfold output.
+    from probe_designer.qc.dimer_ascii import parse_primer3_dimer_pairing  # lazy
+
+    parsed: Dict = parse_primer3_dimer_pairing(ascii_structure or "")
+    pairs = parsed.get("pair_positions_a_to_b") or {}
+    if not pairs:
         return (0, 0), (0, 0)
-    left, right = structure.split("&", 1)
-    len_left = len(left)
-    len_right = len(right)
-    # i is 1-indexed END on A; START_A_1idx = i - len_left + 1; convert to 0-idx half-open
-    start_a = i - len_left  # 1-idx start - 1 = 0-idx start
-    end_a = i               # 1-idx end inclusive == 0-idx exclusive end
-    # j is 1-indexed START on B; END_B_1idx = j + len_right - 1
-    start_b = j - 1
-    end_b = j - 1 + len_right
-    return (start_a, end_a), (start_b, end_b)
+    a_idx = sorted(pairs.keys())
+    b_idx = sorted(pairs.values())
+    return (a_idx[0], a_idx[-1] + 1), (b_idx[0], b_idx[-1] + 1)
 
 
 def predict_pairwise_duplex(
@@ -108,50 +81,52 @@ def predict_pairwise_duplex(
     *,
     probe_a_id: str = "A",
     probe_b_id: str = "B",
-    temperature: float = DEFAULT_TEMPERATURE,
+    reaction: Optional[ReactionConditions] = None,
 ) -> Optional[DuplexHit]:
-    """Compute optimal RNAduplex between two probe sequences.
+    """Optimal DNA:DNA heteroduplex between two probe sequences (primer3).
 
-    Returns ``None`` when ViennaRNA reports no duplex (rare; usually only
-    for empty/very short inputs).
+    Args:
+        probe_a, probe_b: DNA sequences (5'->3').
+        probe_a_id, probe_b_id: identifiers carried into the hit.
+        reaction: buffer conditions; defaults to the protocol
+            :class:`ReactionConditions` (its ``effective_celsius`` is the
+            simulation temperature, so formamide raises stringency).
 
-    The duplex is computed in the **DNA-DNA hybridization regime** for
-    our padlock pool dimerization use case. ViennaRNA's RNA energy
-    parameters are used (no first-class DNA parameter set in
-    ViennaRNA); this is a known approximation. NUPACK ``material='dna'``
-    is the rigorous alternative when concentration-aware competition
-    matters (Phase 2D).
+    Returns:
+        ``DuplexHit``, or ``None`` for empty input or when primer3 finds no
+        structure.
     """
-    if not _HAS_VIENNARNA:
-        raise RuntimeError(
-            "ViennaRNA Python bindings not available. Install via "
-            "`mamba install -n probe-design viennarna`."
-        )
     if not probe_a or not probe_b:
         return None
-    # ViennaRNA uses U; uppercase + T→U for safety.
-    a = probe_a.upper().replace("T", "U")
-    b = probe_b.upper().replace("T", "U")
-    RNA.cvar.temperature = float(temperature)
-    result = RNA.duplexfold(a, b)
-    if result is None:
+    import primer3  # lazy — keeps import cost off the hot path
+
+    reaction = reaction or ReactionConditions()
+    thermo = primer3.calc_heterodimer(
+        probe_a.upper(), probe_b.upper(),
+        output_structure=True,
+        **reaction.primer3_kwargs(),
+    )
+    if not getattr(thermo, "structure_found", False):
         return None
-    span_a, span_b = _parse_duplex_spans(result.structure, result.i, result.j)
+    ascii_structure = str(getattr(thermo, "ascii_structure", "") or "")
+    span_a, span_b = _spans_from_ascii(ascii_structure)
     return DuplexHit(
         probe_a_id=probe_a_id,
         probe_b_id=probe_b_id,
-        delta_g=float(result.energy),
-        structure=str(result.structure),
+        delta_g=float(thermo.dg) / 1000.0,  # primer3 reports cal/mol
+        structure=ascii_structure,
         span_a=span_a,
         span_b=span_b,
     )
 
 
-def _pair_task(args: Tuple[str, str, str, str, float]) -> Optional[DuplexHit]:
+def _pair_task(
+    args: Tuple[str, str, str, str, ReactionConditions]
+) -> Optional[DuplexHit]:
     """ProcessPoolExecutor friendly wrapper (must be importable by name)."""
-    a, b, a_id, b_id, temp = args
+    a, b, a_id, b_id, reaction = args
     return predict_pairwise_duplex(
-        a, b, probe_a_id=a_id, probe_b_id=b_id, temperature=temp,
+        a, b, probe_a_id=a_id, probe_b_id=b_id, reaction=reaction,
     )
 
 
@@ -159,7 +134,7 @@ def screen_all_pairs(
     probes: Sequence[Tuple[str, str]],
     *,
     dg_threshold: float = DEFAULT_DG_THRESHOLD,
-    temperature: float = DEFAULT_TEMPERATURE,
+    reaction: Optional[ReactionConditions] = None,
     n_workers: Optional[int] = None,
 ) -> List[DuplexHit]:
     """All-pairs duplex screen across ``probes``.
@@ -167,25 +142,23 @@ def screen_all_pairs(
     Args:
         probes: sequence of ``(probe_id, probe_sequence)`` tuples.
         dg_threshold: hits with ``delta_g <= dg_threshold`` are returned.
-            Default −12 kcal/mol is the orthogonality threshold; cross-
-            ligation callers should pass ``-10`` (tighter) plus their own
-            junction-span filter.
-        temperature: folding temperature in °C.
-        n_workers: parallelism. ``None`` uses serial execution (avoids
-            ProcessPool startup cost on small panels); set to a positive
-            int to enable workers. ``-1`` uses ``os.cpu_count()``.
+        reaction: buffer conditions (defaults to the protocol conditions).
+        n_workers: parallelism. ``None``/0 runs serially (avoids ProcessPool
+            startup cost on small panels); a positive int enables workers;
+            ``-1`` uses ``os.cpu_count()``.
 
     Returns:
-        List of ``DuplexHit`` for every pair (i, j), i<j, whose ΔG passes
-        the threshold. The same pair is reported once.
+        List of ``DuplexHit`` for every pair (i, j), i<j, whose ΔG passes the
+        threshold. The same pair is reported once.
     """
     items = list(probes)
     pairs = list(combinations(items, 2))
     if not pairs:
         return []
 
+    reaction = reaction or ReactionConditions()
     tasks = [
-        (a_seq, b_seq, a_id, b_id, temperature)
+        (a_seq, b_seq, a_id, b_id, reaction)
         for (a_id, a_seq), (b_id, b_seq) in pairs
     ]
 
@@ -212,7 +185,6 @@ def screen_all_pairs(
 
 __all__ = [
     "DEFAULT_DG_THRESHOLD",
-    "DEFAULT_TEMPERATURE",
     "DuplexHit",
     "predict_pairwise_duplex",
     "screen_all_pairs",

--- a/probe_designer/qc/cross_ligation.py
+++ b/probe_designer/qc/cross_ligation.py
@@ -67,7 +67,7 @@ from itertools import combinations
 from pathlib import Path
 from typing import Any, List, Optional, Set, Tuple
 
-from probe_designer.chemistry import ReactionConditions
+from probe_designer.chemistry import ReactionConditions, reverse_complement
 from probe_designer.qc.dimer_ascii import parse_primer3_dimer_pairing
 
 
@@ -175,11 +175,7 @@ class _SeedSetV22:
 # ----------------------------------------------------------------------
 
 
-_COMP = {"A": "T", "T": "A", "C": "G", "G": "C", "U": "A", "N": "N"}
-
-
-def _rc(seq: str) -> str:
-    return "".join(_COMP.get(b, "N") for b in reversed(seq.upper()))
+_rc = reverse_complement
 
 
 def _kmers(seq: str, k: int) -> Set[str]:

--- a/probe_designer/qc/cross_ligation.py
+++ b/probe_designer/qc/cross_ligation.py
@@ -67,25 +67,23 @@ from itertools import combinations
 from pathlib import Path
 from typing import Any, List, Optional, Set, Tuple
 
+from probe_designer.chemistry import ReactionConditions
 from probe_designer.qc.dimer_ascii import parse_primer3_dimer_pairing
 
 
-# Default thermodynamic parameters (matches lab buffer 2026-05-26).
-#
-# Lab hybridization buffer:
-#   - Ampligase 1× = 20 mM Tris-HCl + 25 mM KCl + 10 mM MgCl2 + 0.5 mM NAD
-#   - + 50 mM extra KCl ⇒ 75 mM total monovalent (K+)
-#   - + 20% formamide ⇒ destabilizes duplex; modeled as +10 °C effective
-#     temperature shift (0.5 °C / %FA × 20%, midpoint of literature range)
-#   - Reaction at 45 °C lab temperature → 55 °C effective in no-formamide NN model
-#   - Probe concentration 0.05–0.2 μM ⇒ 0.1 μM median (1e-7 M)
+# Buffer parameters DERIVED from the single source of truth (ReactionConditions
+# defaults = protocol rca.md v5.3), so the cross-lig screen and the Tm path never
+# drift apart (audit P5). ReactionConditions is bank-free, keeping qc bank-free.
+#   - 75 mM monovalent (K+), 10 mM Mg2+, 0.1 μM probe, 20% formamide → 55 °C
+#     effective in the no-formamide NN model (45 °C lab + 0.5 °C/%FA × 20%).
+_LAB = ReactionConditions()
 DEFAULT_K: int = 4
 DEFAULT_JUNCTION_WINDOW: int = 3
 DEFAULT_TM_THRESHOLD_C: float = 27.0
-DEFAULT_MV_CONC_MM: float = 75.0          # K+ from Ampligase (25) + extra KCl (50)
-DEFAULT_DV_CONC_MM: float = 10.0          # Mg2+ from Ampligase
-DEFAULT_DNA_CONC_M: float = 1.0e-7        # 0.1 μM probe (panel-dependent median)
-DEFAULT_TEMP_C: float = 55.0              # 45 °C lab + 10 °C formamide-equiv (0.5 °C/%FA × 20%)
+DEFAULT_MV_CONC_MM: float = _LAB.monovalent_mM      # 75 mM K+
+DEFAULT_DV_CONC_MM: float = _LAB.mg_mM              # 10 mM Mg2+
+DEFAULT_DNA_CONC_M: float = _LAB.strand_nM * 1e-9   # 0.1 μM probe
+DEFAULT_TEMP_C: float = _LAB.effective_celsius      # 55 °C formamide-effective
 
 # Vicinity contiguity requirement around the ligation nick. SplintR / PBCV-1
 # ligase's active site clamps ~3 nt on each side of the nick (contiguous

--- a/probe_designer/rt_primer.py
+++ b/probe_designer/rt_primer.py
@@ -23,7 +23,11 @@ from typing import Callable, Dict, Optional
 
 from Bio.SeqUtils import MeltingTemp as mt
 
-from probe_designer.chemistry import ReactionConditions, dna_revcomp_to_rna
+from probe_designer.chemistry import (
+    ReactionConditions,
+    dna_revcomp_to_rna,
+    reverse_complement,
+)
 
 
 GenomeAccessor = Callable[[str, int, int], str]
@@ -39,9 +43,7 @@ MAXIMA_H_MINUS_RT = ReactionConditions(
 )
 
 
-def _reverse_complement(seq: str) -> str:
-    comp = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N"}
-    return "".join(comp[b] for b in reversed(seq.upper()))
+_reverse_complement = reverse_complement
 
 
 def _gc_percent(seq: str) -> float:

--- a/probe_designer/search_strategies.py
+++ b/probe_designer/search_strategies.py
@@ -10,6 +10,7 @@ import random  # noqa: F401 (reserved for future stochastic strategies)
 from typing import List, Dict, Any, Tuple, Optional
 from tqdm import tqdm  # noqa: F401 (progress bars may be enabled later)
 
+from .chemistry import reverse_complement
 from .config import SearchConfig, FilterConfig
 from .filtering import SequenceFilter
 
@@ -29,10 +30,6 @@ class SearchStrategy:
         """Search binding sites (must be implemented by subclasses)."""
         raise NotImplementedError
     
-    def _reverse_complement(self, sequence: str) -> str:
-        """Return reverse complement of a DNA sequence."""
-        complement = {"A": "T", "T": "A", "C": "G", "G": "C", "N": "N"}
-        return "".join(complement[base] for base in reversed(sequence))
 
 
 class SingleSequenceStrategy(SearchStrategy):
@@ -75,7 +72,7 @@ class SingleSequenceStrategy(SearchStrategy):
         for pos in position_iterator:
             target_seq = sequence[pos:pos + bds_len]
             # Get reverse complement for probe design (DNA probe binding to RNA target)
-            probe_seq = self._reverse_complement(target_seq)
+            probe_seq = reverse_complement(target_seq)
             
             # Split probe sequence into arms (3' arm is front, 5' arm is back for padlock probe)
             arm_3prime = probe_seq[:bds_len//2]  # Front half
@@ -174,7 +171,7 @@ class ExonJunctionStrategy(SearchStrategy):
                 break
             target_seq = sequence[pos:pos + bds_len]
             # Get reverse complement for probe design (DNA probe binding to RNA target)
-            probe_seq = self._reverse_complement(target_seq)
+            probe_seq = reverse_complement(target_seq)
             
             # Split probe sequence into arms (3' arm is front, 5' arm is back for padlock probe)
             arm_3prime = probe_seq[:bds_len//2]  # Front half
@@ -351,7 +348,7 @@ class IsoformAwareStrategy(SearchStrategy):
                     target_seq = self.awareness.get_target_seq(target_regions, strand)
                     
                     # Get reverse complement for probe design (DNA probe binding to RNA target)
-                    probe_seq = self._reverse_complement(target_seq)
+                    probe_seq = reverse_complement(target_seq)
                     
                     # Split probe sequence into arms (3' arm is front, 5' arm is back for padlock probe)
                     arm_3prime = probe_seq[:bds_len//2]  # Front half

--- a/tests/unit/test_chemistry.py
+++ b/tests/unit/test_chemistry.py
@@ -12,7 +12,11 @@ import math
 import pytest
 from Bio.SeqUtils import MeltingTemp as mt
 
-from probe_designer.chemistry import ReactionConditions, dna_revcomp_to_rna
+from probe_designer.chemistry import (
+    ReactionConditions,
+    dna_revcomp_to_rna,
+    register_solvent,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +124,53 @@ class TestFormamideCorrection:
     def test_zero_formamide_is_noop(self):
         rc = ReactionConditions(formamide_pct=0.0)
         assert rc.apply_formamide(60.0) == pytest.approx(60.0)
+
+
+class TestFromBuffer:
+    def test_granular_monovalents_fold_to_total(self):
+        # Na/K/Tris are equivalent for Tm; total = Na + K + Tris/2.
+        rc = ReactionConditions.from_buffer(na_mM=25.0, k_mM=50.0)
+        assert rc.monovalent_mM == 75.0
+
+    def test_tris_counts_half(self):
+        rc = ReactionConditions.from_buffer(k_mM=50.0, tris_mM=50.0)
+        assert rc.monovalent_mM == 75.0  # 50 + 50/2
+
+    def test_other_kwargs_pass_through(self):
+        rc = ReactionConditions.from_buffer(k_mM=75.0, mg_mM=4.0, formamide_pct=0.0)
+        assert rc.mg_mM == 4.0 and rc.formamide_pct == 0.0
+
+
+class TestSolvents:
+    def test_default_solvents_empty_matches_formamide_only(self):
+        rc = ReactionConditions()
+        # 20% formamide * 0.5 = 10 C, no extra solvents.
+        assert rc.solvent_tm_depression == pytest.approx(10.0)
+        assert rc.effective_celsius == pytest.approx(55.0)
+
+    def test_extra_solvent_adds_depression(self):
+        rc = ReactionConditions(solvents={"dmso": 10.0})  # +0.6*10 = 6
+        assert rc.solvent_tm_depression == pytest.approx(16.0)
+        assert rc.apply_solvents(60.0) == pytest.approx(44.0)
+        assert rc.effective_celsius == pytest.approx(61.0)
+
+    def test_apply_formamide_alias_still_works(self):
+        assert ReactionConditions().apply_formamide(60.0) == pytest.approx(50.0)
+
+    def test_unknown_solvent_raises_until_registered(self):
+        rc = ReactionConditions(solvents={"betaine": 20.0})
+        with pytest.raises(ValueError, match="register_solvent"):
+            _ = rc.solvent_tm_depression
+        register_solvent("betaine", 0.0)  # isostabilizer ~ no net Tm shift here
+        assert rc.solvent_tm_depression == pytest.approx(10.0)  # formamide only
+
+    def test_negative_solvent_percent_rejected(self):
+        with pytest.raises(ValueError):
+            ReactionConditions(solvents={"dmso": -1.0})
+
+    def test_signature_distinguishes_solvents(self):
+        assert (ReactionConditions().signature()
+                != ReactionConditions(solvents={"dmso": 5.0}).signature())
 
 
 class TestEngineKwargs:

--- a/tests/unit/test_chemistry.py
+++ b/tests/unit/test_chemistry.py
@@ -16,7 +16,57 @@ from probe_designer.chemistry import (
     ReactionConditions,
     dna_revcomp_to_rna,
     register_solvent,
+    reverse_complement,
 )
+
+
+# ---------------------------------------------------------------------------
+# reverse_complement — the package's single implementation
+# ---------------------------------------------------------------------------
+
+class TestReverseComplement:
+    """Contract for the canonical implementation.
+
+    This replaced seven private copies that had diverged on three axes, so the
+    contract is pinned rather than assumed. Each case below is a behaviour one
+    of the replaced copies depended on; together they are the superset that
+    makes the consolidation safe.
+    """
+
+    def test_basic(self):
+        assert reverse_complement("ACGG") == "CCGT"
+
+    def test_uppercases_lowercase_input(self):
+        # search_strategies and ext/mutation did NOT uppercase and would raise
+        # KeyError here. The canonical version accepts either case.
+        assert reverse_complement("acgg") == "CCGT"
+
+    def test_unknown_base_becomes_n_rather_than_raising(self):
+        # Four of the replaced copies raised KeyError; the two shared helpers
+        # mapped to N. N is chosen so one stray character cannot kill a batch.
+        assert reverse_complement("ACXG") == "CNGT"
+
+    def test_u_is_read_as_t(self):
+        # cross_ligation accepted RNA input; nothing else did.
+        assert reverse_complement("ACGU") == "ACGT"
+
+    def test_gap_is_preserved(self):
+        # ext/tcr aligns clone sequences and needs '-' to survive.
+        assert reverse_complement("AC-G") == "C-GT"
+
+    def test_n_maps_to_itself(self):
+        assert reverse_complement("acgn") == "NCGT"
+
+    def test_double_rc_is_identity(self):
+        arm = "GATCGGATCCATTGCA"
+        assert reverse_complement(reverse_complement(arm)) == arm
+
+    def test_empty(self):
+        assert reverse_complement("") == ""
+
+    def test_dna_revcomp_to_rna_is_the_same_function(self):
+        for seq in ("AAAC", "acgn", "GATCGGATCC", ""):
+            assert dna_revcomp_to_rna(seq) == reverse_complement(seq)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pairwise_duplex.py
+++ b/tests/unit/test_pairwise_duplex.py
@@ -1,16 +1,24 @@
-"""Tests for filtering/pairwise_duplex.py (Phase 1B, 2026-05-14)."""
+"""Tests for filtering/pairwise_duplex.py — primer3 DNA backend (audit R5/P3).
+
+Rewritten 2026-07-20: the backend moved from ViennaRNA ``duplexfold`` (RNA
+Turner parameters — the wrong physics for a DNA:DNA padlock dimer, and the
+source of the dot-bracket/T→U behaviour these tests used to pin) to primer3's
+SantaLucia DNA nearest-neighbor model evaluated at the real buffer. ΔG
+magnitudes are not comparable to the old RNA-parameter values, so assertions are
+relational where possible.
+"""
 from __future__ import annotations
 
 import pytest
 
-from probe_designer.filtering.pairwise_duplex import (
+pytest.importorskip("primer3")
+
+from probe_designer.chemistry import ReactionConditions           # noqa: E402
+from probe_designer.filtering.pairwise_duplex import (            # noqa: E402
     DEFAULT_DG_THRESHOLD,
-    DuplexHit,
-    _parse_duplex_spans,
     predict_pairwise_duplex,
     screen_all_pairs,
 )
-
 
 REV_COMP_PAIR = (
     "GATGATGATGATGATGATGC",        # 20-mer
@@ -18,7 +26,7 @@ REV_COMP_PAIR = (
 )
 RANDOM_PAIR = (
     "ACGTACGTACGTACGTACGT",
-    "TTTAAACCCGGGAAATTTCC",
+    "AAAGAAAGAAAGAAAGAAAG",
 )
 
 
@@ -26,18 +34,13 @@ class TestPredictPairwiseDuplex:
     def test_reverse_complement_pair_returns_strong_duplex(self):
         hit = predict_pairwise_duplex(*REV_COMP_PAIR)
         assert hit is not None
-        assert hit.delta_g < -20.0, f"expected strong duplex, got {hit.delta_g}"
-        assert "(" in hit.structure and ")" in hit.structure
-        assert "&" in hit.structure
+        assert hit.delta_g < -10.0, f"expected strong duplex, got {hit.delta_g}"
 
-    def test_random_pair_returns_weak_or_none(self):
-        hit = predict_pairwise_duplex(*RANDOM_PAIR)
-        # Either no duplex or a weak one — let the orthogonality threshold
-        # be the actual gate; here we just assert it's nothing dramatic.
-        if hit is not None:
-            assert hit.delta_g > -10.0, (
-                f"random pair shouldn't bind strongly; got {hit.delta_g}"
-            )
+    def test_random_pair_much_weaker_than_rc(self):
+        rc = predict_pairwise_duplex(*REV_COMP_PAIR)
+        rnd = predict_pairwise_duplex(*RANDOM_PAIR)
+        rnd_dg = rnd.delta_g if rnd is not None else 0.0
+        assert rc.delta_g < rnd_dg - 5.0
 
     def test_returns_none_on_empty_strand(self):
         assert predict_pairwise_duplex("", "ACGT") is None
@@ -50,44 +53,39 @@ class TestPredictPairwiseDuplex:
         assert hit.probe_a_id == "ProbeA"
         assert hit.probe_b_id == "ProbeB"
 
-    def test_dna_letters_normalized_to_rna(self):
-        """T→U substitution is transparent at the API level: same energy
-        either way."""
-        hit_dna = predict_pairwise_duplex(
-            "GATGATGATGATGATGATGC", "GCATCATCATCATCATCATC",
+    def test_structure_is_primer3_ascii(self):
+        hit = predict_pairwise_duplex(*REV_COMP_PAIR)
+        assert "SEQ" in hit.structure or "STR" in hit.structure
+
+    def test_spans_within_bounds_and_nonempty(self):
+        a, b = REV_COMP_PAIR
+        hit = predict_pairwise_duplex(a, b)
+        (a0, a1), (b0, b1) = hit.span_a, hit.span_b
+        assert 0 <= a0 < a1 <= len(a)
+        assert 0 <= b0 < b1 <= len(b)
+
+
+class TestBufferAwareness:
+    """The screen now sees the real buffer (audit P5/R5), not a bare temperature."""
+
+    def test_higher_temperature_weakens_duplex(self):
+        cold = predict_pairwise_duplex(
+            *REV_COMP_PAIR,
+            reaction=ReactionConditions(lab_temp_c=25.0, formamide_pct=0.0),
         )
-        hit_rna = predict_pairwise_duplex(
-            "GAUGAUGAUGAUGAUGAUGC", "GCAUCAUCAUCAUCAUCAUC",
+        hot = predict_pairwise_duplex(
+            *REV_COMP_PAIR,
+            reaction=ReactionConditions(lab_temp_c=70.0, formamide_pct=0.0),
         )
-        assert hit_dna is not None and hit_rna is not None
-        assert hit_dna.delta_g == pytest.approx(hit_rna.delta_g)
+        assert hot.delta_g > cold.delta_g
 
-    def test_temperature_change_weakens_duplex(self):
-        """At higher temperature, duplex ΔG should be less negative
-        (weaker pairing). This is the 'formamide approximation' knob."""
-        hit_cold = predict_pairwise_duplex(*REV_COMP_PAIR, temperature=20.0)
-        hit_hot = predict_pairwise_duplex(*REV_COMP_PAIR, temperature=60.0)
-        assert hit_cold is not None and hit_hot is not None
-        assert hit_hot.delta_g > hit_cold.delta_g, (
-            f"hot ({hit_hot.delta_g}) should be > cold ({hit_cold.delta_g})"
-        )
-
-
-class TestParseDuplexSpans:
-    def test_full_match_spans_both_strands(self):
-        # structure with 20 brackets each side, i=20, j=1
-        struct = "(" * 20 + "&" + ")" * 20
-        span_a, span_b = _parse_duplex_spans(struct, i=20, j=1)
-        assert span_a == (0, 20)
-        assert span_b == (0, 20)
-
-    def test_partial_match_in_middle(self):
-        # 5-bp duplex; left brackets are 5, structure positions 6..10 on A
-        # (1-indexed). i = 10. Right is 5 brackets, j = 1 on B.
-        struct = "(((((&)))))"
-        span_a, span_b = _parse_duplex_spans(struct, i=10, j=1)
-        assert span_a == (5, 10)
-        assert span_b == (0, 5)
+    def test_formamide_raises_effective_temperature(self):
+        no_fa = predict_pairwise_duplex(
+            *REV_COMP_PAIR, reaction=ReactionConditions(formamide_pct=0.0))
+        with_fa = predict_pairwise_duplex(
+            *REV_COMP_PAIR, reaction=ReactionConditions(formamide_pct=20.0))
+        # formamide -> hotter effective temperature -> weaker duplex
+        assert with_fa.delta_g > no_fa.delta_g
 
 
 class TestScreenAllPairs:
@@ -95,33 +93,26 @@ class TestScreenAllPairs:
         assert screen_all_pairs([]) == []
 
     def test_single_probe_returns_empty(self):
-        assert screen_all_pairs([("only", "ACGT")]) == []
+        assert screen_all_pairs([("only", "ACGTACGTACGTACGTACGT")]) == []
 
-    def test_flags_only_below_threshold(self):
-        # 4 probes:
-        # A and B are RC of each other → strong duplex
-        # C and D are random → weak/no duplex
+    def test_flags_complementary_pair(self):
         probes = [
-            ("A", "GATGATGATGATGATGATGC"),
-            ("B", "GCATCATCATCATCATCATC"),
-            ("C", "ACGTACGTACGTACGTACGT"),
-            ("D", "AAAAATTTTGGGGCCCCTTT"),
+            ("A", REV_COMP_PAIR[0]),
+            ("B", REV_COMP_PAIR[1]),
+            ("C", "AAAGAAAGAAAGAAAGAAAG"),
         ]
-        # default threshold -12 kcal/mol
-        hits = screen_all_pairs(probes)
-        # AB pair must be flagged
+        hits = screen_all_pairs(probes, dg_threshold=-10.0)
         ab_hits = [h for h in hits
                    if {h.probe_a_id, h.probe_b_id} == {"A", "B"}]
         assert len(ab_hits) == 1
-        assert ab_hits[0].delta_g <= -12.0
+        assert ab_hits[0].delta_g <= -10.0
 
     def test_threshold_kwarg_respected(self):
-        probes = [
-            ("A", "GATGATGATGATGATGATGC"),
-            ("B", "GCATCATCATCATCATCATC"),
-        ]
-        # A very tight threshold (impossible to reach) returns no hits.
+        probes = [("A", REV_COMP_PAIR[0]), ("B", REV_COMP_PAIR[1])]
+        # Unreachable threshold -> nothing passes.
         assert screen_all_pairs(probes, dg_threshold=-9999.0) == []
-        # A very loose threshold (everything passes) returns the pair.
-        loose = screen_all_pairs(probes, dg_threshold=0.0)
-        assert len(loose) == 1
+        # Loose threshold -> the pair is returned.
+        assert len(screen_all_pairs(probes, dg_threshold=0.0)) == 1
+
+    def test_default_threshold_constant(self):
+        assert DEFAULT_DG_THRESHOLD == -12.0

--- a/tests/unit/test_reaction_config.py
+++ b/tests/unit/test_reaction_config.py
@@ -43,6 +43,10 @@ class TestFilterConfigBufferFields:
         with pytest.raises(ValueError):
             FilterConfig(mg_mM=-1.0).reaction_conditions()
 
+    def test_solvents_pass_through(self):
+        rc = FilterConfig(solvents={"dmso": 5.0}).reaction_conditions()
+        assert rc.solvents == {"dmso": 5.0}
+
 
 class TestBufferYamlRoundTrip:
     def test_load_config_picks_up_buffer_keys(self):

--- a/tests/unit/test_screen_buffer_unified.py
+++ b/tests/unit/test_screen_buffer_unified.py
@@ -1,0 +1,46 @@
+"""The cross-lig / NUPACK screen buffers derive from ReactionConditions (P5).
+
+Locks the single-source-of-truth: the screen constants must equal the shared
+ReactionConditions defaults, and keep their historical numeric values so this
+unification is behavior-preserving.
+"""
+from __future__ import annotations
+
+import pytest
+
+from probe_designer.chemistry import ReactionConditions
+
+_LAB = ReactionConditions()
+
+
+class TestCrossLigationBufferDerived:
+    def test_matches_reaction_conditions(self):
+        from probe_designer.qc import cross_ligation as xl
+        assert xl.DEFAULT_MV_CONC_MM == _LAB.monovalent_mM
+        assert xl.DEFAULT_DV_CONC_MM == _LAB.mg_mM
+        assert xl.DEFAULT_DNA_CONC_M == _LAB.strand_nM * 1e-9
+        assert xl.DEFAULT_TEMP_C == _LAB.effective_celsius
+
+    def test_historical_values_unchanged(self):
+        from probe_designer.qc import cross_ligation as xl
+        assert xl.DEFAULT_MV_CONC_MM == 75.0
+        assert xl.DEFAULT_DV_CONC_MM == 10.0
+        assert xl.DEFAULT_DNA_CONC_M == pytest.approx(1.0e-7)
+        assert xl.DEFAULT_TEMP_C == 55.0
+
+
+class TestNupackBufferDerived:
+    def test_matches_reaction_conditions(self):
+        from probe_designer.ext.nupack import config as nc
+        nk = _LAB.nupack_kwargs()
+        assert nc.DEFAULT_SODIUM_M == nk["sodium"]
+        assert nc.DEFAULT_MAGNESIUM_M == nk["magnesium"]
+        assert nc.DEFAULT_CELSIUS == nk["celsius"]
+        assert nc.DEFAULT_STRAND_CONC_M == _LAB.strand_nM * 1e-9
+
+    def test_historical_values_unchanged(self):
+        from probe_designer.ext.nupack import config as nc
+        assert nc.DEFAULT_SODIUM_M == pytest.approx(0.075)
+        assert nc.DEFAULT_MAGNESIUM_M == pytest.approx(0.010)
+        assert nc.DEFAULT_CELSIUS == 55.0
+        assert nc.DEFAULT_STRAND_CONC_M == pytest.approx(1.0e-7)


### PR DESCRIPTION
## Summary

**Phase 2** of the thermodynamics audit. Makes the buffer model *flexible*
(arbitrary co-solvents, granular ion input), collapses the duplicated screen
buffers onto the single `ReactionConditions` source of truth (**audit P5**), and
fixes the panel orthogonality screen to use **DNA** physics instead of RNA
parameters (**audit R5/P3**).

> **Stacked on #6** (`feature/reaction-conditions-buffer`) — it needs
> `ReactionConditions`. Review this diff alone; retarget to `main` once #6 merges.

## What changed

**Flexible buffer model** (from review feedback: "what if I change the ion or solvent?")
- `ReactionConditions.solvents` (`{name: % v/v}`) + a `SOLVENT_TM_COEFF` registry
  (formamide/DMSO built in) and `register_solvent(name, coeff)` for a denaturant
  with no built-in NN term (betaine, glycol, …).
- `ReactionConditions.from_buffer(na_mM=, k_mM=, tris_mM=)` — monovalents are
  *equivalent* for Tm, so they fold into the total (`Na + K + Tris/2`).
- `apply_formamide` → `apply_solvents` (alias kept); `effective_celsius` and
  `signature()` account for every solvent; `FilterConfig.solvents` round-trips
  through YAML.
- **Honest limits, documented + fail-fast:** Tm-from-buffer is only as flexible as
  the correction *physics* — monovalents are equivalent, Mg²⁺ is the only modelled
  divalent, and an unregistered solvent raises rather than silently returning a
  wrong Tm.
- Fully backward compatible (`monovalent_mM` / `formamide_pct` unchanged).

**Screen buffers unified (P5)**
- `qc/cross_ligation.py` and `ext/nupack/config.py` each hard-coded the lab
  buffer; both now derive it from the `ReactionConditions` defaults. Values
  unchanged (75 mM monovalent / 10 mM Mg²⁺ / 0.1 µM / 55 °C effective), so this is
  behavior-preserving — locked by a new test.

**Orthogonality screen: DNA physics (R5/P3)**
- `filtering/pairwise_duplex.py` scored padlock–padlock **DNA:DNA** dimers with
  ViennaRNA's **RNA** Turner parameters. It now uses **primer3**
  (SantaLucia unified DNA NN) at the real buffer, sharing physics with the
  cross-ligation screen. `DuplexHit` keeps its shape (structure is the primer3
  ASCII dimer; spans recovered via `qc.dimer_ascii`).
- ΔG magnitudes are **not** comparable to the old RNA-parameter values — the
  −12 kcal/mol default stays a permissive *log-only* threshold; re-tune before
  ever using it to drop probes. Tests rewritten accordingly. No production
  consumer outside the module.

**Reverse-complement consolidation** (@tangmc0210)
- Seven near-identical `reverse_complement` helpers had quietly diverged on
  case handling, unknown bases, and alphabet (`U`, gap `-`). Collapsed into a
  single `chemistry.reverse_complement` that is the superset of all seven
  behaviours; `dna_revcomp_to_rna` stays as a named alias because at the Tm call
  sites "produce the strand `R_DNA_NN1` requires" is the readable intent.

## Testing

`python -m pytest` → **577 passed, 1 skipped**. New/updated tests cover the
solvent registry + `from_buffer` + backward-compat aliases, the derived screen
constants (single source of truth), and the primer3 duplex backend.

## Deferred

Phase 3 (R4 arm-Tm balance, R7 config reconcile, R8 `free_energy`, R9 RNAplfold
window, R10 declare `primer3-py`) and Phase 4 (R6 Banerjee 2020 hybrid NN), each
as its own PR. Plus mutation/TCR/pool CLI buffer flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
