### PR TITLE
Phase 3: one owner per rule — ThermoPolicy, FoldingConditions, honest sentinels (R4, R7, R8, R9, R10)

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -87,52 +87,56 @@
 
 ### 3. Filter 配置
 
-```json
-"filter": {
-  "min_g_content": 0.3,
-  "max_g_content": 0.7,
-  "max_consecutive_g": 3,
-  "min_tm": 60.0,
-  "max_tm": 80.0,
-  "max_tm_diff": 5.0,
-  "min_free_energy": -5.0,
-  "check_rna_structure": true,
-  "max_alignments": 10,
-  "require_specificity": true,
-  "target_organisms": ["Mus musculus", "Homo sapiens"],
-  "final_probes_per_gene": 3
-}
+> **Source of truth:** `probe_designer/config/FilterConfig` (defaults) and
+> `configs/config_template.yaml` (annotated template). The values below are
+> illustrative; when they disagree with the dataclass, the dataclass wins.
+
+```yaml
+filter:
+  min_gc_content: 0.35       # Schema-v2 gate (GC%, not G-only)
+  max_gc_content: 0.65
+  max_consecutive_g: 5
+  min_tm: 50.0               # arm-Tm target = lab_temp_c + tm_margin_c
+  max_tm: 70.0
+  max_tm_diff: 5.0           # two-arm balance tolerance
+  enforce_tm_gate: false     # Tm rules are scoring references, not cutoffs
+  enforce_tm_diff_gate: false
+  min_free_energy: -10.0
+  check_rna_structure: true
+  max_alignments: 5
+  require_specificity: true
+  target_organisms: ["Mus musculus", "Homo sapiens"]
+  final_probes_per_gene: 3
 ```
 
-#### min_g_content / max_g_content
-- **含义**: G碱基含量的最小/最大值（0-1之间）
-- **可能的值**: 0.0-1.0
-- **推荐值**: `0.3-0.7`
-- **默认值**: `0.3` / `0.7`
+#### min_gc_content / max_gc_content
+- **含义**: 每条臂的 G+C 含量下/上限（Schema-v2 实际生效的门槛）
+- **推荐值**: `0.35-0.65`（2026-05-13 BZ23/TNBC 审计锚定）
+- **默认值**: `0.35` / `0.65`
+- 旧的 `min_g_content` / `max_g_content` 只数 G，已废弃，仅为向后兼容保留，不再生效。
 
 #### max_consecutive_g
-- **含义**: 允许的最大连续G碱基数量
-- **可能的值**: 正整数
-- **推荐值**: `3-4`
-- **默认值**: `3`
+- **含义**: 允许的最大连续 G 碱基数量（A/T/C 同样有各自的门槛）
+- **默认值**: `5`
 
 #### min_tm / max_tm
-- **含义**: 熔解温度的最小/最大值（摄氏度）
-- **可能的值**: 正数
-- **推荐值**: `50-80°C`
-- **默认值**: `60.0` / `80.0`
+- **含义**: 臂熔解温度的目标与上界（摄氏度），锚定到反应温度
+  `lab_temp_c + tm_margin_c`，并在真实缓冲液（含 Mg²⁺ 与甲酰胺）下计算
+- **默认值**: `50.0` / `70.0`
+- **注意**: 默认是**打分参考**而非硬门槛 —— 离目标越远排名越低，但不会被丢弃。
+  需要恢复硬性拒绝时把 `enforce_tm_gate` 设为 `true`。
 
 #### max_tm_diff
-- **含义**: 3'和5'臂之间的最大熔解温度差异
-- **可能的值**: 正数
-- **推荐值**: `5-10°C`
+- **含义**: 3' 与 5' 臂之间的熔解温度差异容忍度
+- **推荐值**: `3-5°C`（Larsson 2010 / Krzywkowski 2017）
 - **默认值**: `5.0`
+- **注意**: 同样是打分参考；`enforce_tm_diff_gate` 才会让它变成硬门槛。在 232 条已下单
+  探针上，5°C 的硬门槛会拒掉 17.7%，而作为打分参考则零代价。
 
 #### min_free_energy
-- **含义**: RNA二级结构的最小自由能（kcal/mol）
+- **含义**: RNA 二级结构的最小自由能（kcal/mol）
 - **可能的值**: 负数或0
-- **推荐值**: `-10.0` 到 `0.0`
-- **默认值**: `-5.0`
+- **默认值**: `-10.0`
 
 #### check_rna_structure
 - **含义**: 是否检查RNA二级结构
@@ -365,16 +369,19 @@
 ```
 
 ### 高特异性探针设计
-```json
-{
-  "filter": {
-    "min_tm": 65.0,
-    "max_tm": 75.0,
-    "max_tm_diff": 3.0,
-    "max_consecutive_g": 2
-  }
-}
+
+收紧容忍度并把它们打开成硬门槛 —— 只有在你确实愿意为特异性丢掉候选时才这么做。
+
+```yaml
+filter:
+  max_tm_diff: 3.0            # 更严格的双臂平衡
+  max_consecutive_g: 4
+  enforce_tm_gate: true       # 让 [min_tm, max_tm] 真正拒绝候选
+  enforce_tm_diff_gate: true
 ```
+
+若只是想提高杂交温度，改 `lab_temp_c` 即可 —— `min_tm` 会跟着
+`lab_temp_c + tm_margin_c` 一起移动，不需要手动改阈值。
 
 ### 快速筛选模式
 ```json

--- a/configs/config_consensus.yaml
+++ b/configs/config_consensus.yaml
@@ -26,7 +26,7 @@ filter:
   max_consecutive_c: 5
   min_tm: 50.0   # = lab_temp_c + tm_margin_c (45 + 5), re-anchored 2026-07-17
   max_tm: 70.0   # = lab_temp_c + 25
-  max_tm_diff: 10.0
+  max_tm_diff: 5.0    # two-arm balance tolerance (°C); scoring reference, gate is soft
   min_free_energy: -10.0
   check_rna_structure: true
   require_specificity: true

--- a/configs/config_consensus.yaml
+++ b/configs/config_consensus.yaml
@@ -36,10 +36,14 @@ filter:
   # each candidate window is gated. 0.30 is recommended once Phase 1A is
   # validated against a wet-lab panel; keep at 0 to use the legacy self-fold
   # MFE check for now.
+  # Geometry: Lange 2012 (W = L + 50, L ~ 100). The former W=70/L=40 could not
+  # represent a base pair spanning >40 nt, so sites behind a long-range stem
+  # read as open. Temperature is omitted on purpose — it then tracks the
+  # reaction (lab_temp_c + solvent depression), keeping this profile identical
+  # to the one written into the reference annotation. Set a number to pin it.
   min_accessibility: 0.0
-  plfold_window: 70
-  plfold_span: 40
-  plfold_temperature: 37.0   # raise to 47-55 to approximate formamide
+  plfold_window: 150
+  plfold_span: 100
 
 blast:
   blast_type: "local"

--- a/configs/config_consensus.yaml
+++ b/configs/config_consensus.yaml
@@ -30,7 +30,9 @@ filter:
   min_free_energy: -10.0
   check_rna_structure: true
   require_specificity: true
-  final_probes_per_gene: 3
+  # NOTE: probes per gene is a SELECTION knob, not a filter one — use the
+  # `--top-n` CLI option. The former `final_probes_per_gene` key here was never
+  # a FilterConfig field, so the loader silently ignored it.
   # Phase 1A (2026-05-14): target-accessibility gate. When > 0, RNAplfold
   # profiles are computed per isoform and the mean unpaired-probability of
   # each candidate window is gated. 0.30 is recommended once Phase 1A is

--- a/configs/config_single_sequence.yaml
+++ b/configs/config_single_sequence.yaml
@@ -31,7 +31,9 @@ filter:
   min_free_energy: -10.0
   check_rna_structure: true
   require_specificity: true
-  final_probes_per_gene: 3
+  # NOTE: probes per gene is a SELECTION knob, not a filter one — use the
+  # `--top-n` CLI option. The former `final_probes_per_gene` key here was never
+  # a FilterConfig field, so the loader silently ignored it.
 
 blast:
   blast_type: "local"

--- a/configs/config_single_sequence.yaml
+++ b/configs/config_single_sequence.yaml
@@ -27,7 +27,7 @@ filter:
   max_consecutive_c: 5
   min_tm: 50.0   # = lab_temp_c + tm_margin_c (45 + 5), re-anchored 2026-07-17
   max_tm: 70.0   # = lab_temp_c + 25
-  max_tm_diff: 10.0
+  max_tm_diff: 5.0    # two-arm balance tolerance (°C); scoring reference, gate is soft
   min_free_energy: -10.0
   check_rna_structure: true
   require_specificity: true

--- a/configs/config_specific.yaml
+++ b/configs/config_specific.yaml
@@ -30,7 +30,9 @@ filter:
   min_free_energy: -10.0
   check_rna_structure: true
   require_specificity: true
-  final_probes_per_gene: 3
+  # NOTE: probes per gene is a SELECTION knob, not a filter one — use the
+  # `--top-n` CLI option. The former `final_probes_per_gene` key here was never
+  # a FilterConfig field, so the loader silently ignored it.
   # Phase 1A: target-accessibility gate (RNAplfold). 0 disables; set to 0.30 to enable.
   # Geometry per Lange 2012 (W = L + 50, L ~ 100); omitting plfold_temperature
   # makes folding track the reaction temperature. See config_consensus.yaml.

--- a/configs/config_specific.yaml
+++ b/configs/config_specific.yaml
@@ -32,10 +32,11 @@ filter:
   require_specificity: true
   final_probes_per_gene: 3
   # Phase 1A: target-accessibility gate (RNAplfold). 0 disables; set to 0.30 to enable.
+  # Geometry per Lange 2012 (W = L + 50, L ~ 100); omitting plfold_temperature
+  # makes folding track the reaction temperature. See config_consensus.yaml.
   min_accessibility: 0.0
-  plfold_window: 70
-  plfold_span: 40
-  plfold_temperature: 37.0
+  plfold_window: 150
+  plfold_span: 100
 
 blast:
   blast_type: "local"

--- a/configs/config_specific.yaml
+++ b/configs/config_specific.yaml
@@ -26,7 +26,7 @@ filter:
   max_consecutive_c: 5
   min_tm: 50.0
   max_tm: 70.0
-  max_tm_diff: 10.0
+  max_tm_diff: 5.0    # two-arm balance tolerance (°C); scoring reference, gate is soft
   min_free_energy: -10.0
   check_rna_structure: true
   require_specificity: true

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -48,9 +48,17 @@ filter:
   max_consecutive_a: 5  # Maximum consecutive A nucleotides per arm (Schema-v2)
   max_consecutive_t: 5  # Maximum consecutive T nucleotides per arm (Schema-v2)
   max_consecutive_c: 5  # Maximum consecutive C nucleotides per arm (Schema-v2)
-  min_tm: 50.0  # Minimum melting temperature (°C); anchored to lab_temp_c + tm_margin_c
-  max_tm: 70.0  # Maximum melting temperature (°C); anchored to lab_temp_c + 25
-  max_tm_diff: 10.0  # Maximum temperature difference between 3' and 5' arms (°C)
+  # Arm-Tm rules. These are SCORING references by default, not cutoffs: a
+  # candidate far from the target ranks lower but is not discarded, because the
+  # hybrid-Tm model carries a few degrees of error and a cliff throws away good
+  # probes for landing on the wrong side of it. Flip the enforce_* switches to
+  # restore hard rejection. Both the filter and the ranker read these through
+  # policy.ThermoPolicy, so they cannot drift apart.
+  min_tm: 50.0  # Arm-Tm target (°C); anchored to lab_temp_c + tm_margin_c
+  max_tm: 70.0  # Upper arm-Tm bound (°C); anchored to lab_temp_c + 25
+  max_tm_diff: 5.0  # Two-arm Tm balance tolerance (°C); Larsson 2010 / Krzywkowski 2017
+  enforce_tm_gate: false       # true = reject arms outside [min_tm, max_tm]
+  enforce_tm_diff_gate: false  # true = reject probes whose arms differ by > max_tm_diff
   min_free_energy: -10.0  # Minimum RNA secondary structure free energy (kcal/mol)
   check_rna_structure: true  # Whether to check RNA secondary structure
 

--- a/docs/thermodynamics_parameters.md
+++ b/docs/thermodynamics_parameters.md
@@ -116,13 +116,74 @@ arms (`experiments/20260717_tm_buffer_config_impl/output/impact_summary.txt`).
 
 **Soft Tm scoring (2026-07-19).** The hard [min_tm, max_tm] gate is **off by
 default** (`FilterConfig.enforce_tm_gate = False`); absolute arm Tm is instead a
-**soft, two-sided** scoring term (`scoring.compute_target_score` `tm_proximity`)
-that peaks at the reaction-anchored target (`min_tm` = `lab_temp_c + tm_margin_c`,
-≈ 50 °C — a few °C above the 45 °C hyb temp so arms stay bound, per Krzywkowski
-2017) and falls off in both directions. Candidates rank by score rather than
-being dropped on Tm. `min_tm`/`max_tm` are the scoring target/reference; set
-`enforce_tm_gate = True` to restore the hard cutoff. TCR's per-clone selection
-(`ext/tcr/probe.filter_by_chemistry_tm`) still hard-gates — separate follow-up.
+**soft, two-sided** scoring term that peaks at the reaction-anchored target
+(`min_tm` = `lab_temp_c + tm_margin_c`, ≈ 50 °C — a few °C above the 45 °C hyb
+temp so arms stay bound, per Krzywkowski 2017) and falls off in both directions.
+Candidates rank by score rather than being dropped on Tm. `min_tm`/`max_tm` are
+the scoring target/reference; set `enforce_tm_gate = True` to restore the hard
+cutoff. TCR's per-clone selection also went soft in the same change.
+
+### 5a. One rule, one definition — `policy.ThermoPolicy` (2026-07-21)
+
+The arm-Tm rules used to exist **twice**: `filtering/` held the thresholds it
+rejects on, `scoring/` held its own copies to rank with — and they had drifted
+(`compute_target_score` defaulted to `min_arm_tm=50 / max_tm_diff=10` regardless
+of `FilterConfig`, whose own `min_tm` default of 45 contradicted every shipped
+YAML's 50). That is audit **R7**, and its cause is duplication rather than any
+one wrong number.
+
+`ThermoPolicy` now owns both the thresholds **and** their normalized 0–1 scoring
+shapes; `scoring` keeps only the composite *weights* (how much Tm proximity is
+worth against isoform coverage is a ranking decision, not a thermodynamic one),
+and `filtering` keeps its per-call override surface. Build one with
+`ThermoPolicy.resolve(filter_config)` or `ThermoPolicy.from_reaction(reaction)`
+— the latter re-anchors the target when you change `lab_temp_c`, so raising the
+hyb temperature moves what counts as a good arm without editing a threshold.
+
+| Parameter | Value | Set at | Source |
+|---|---|---|---|
+| Two-arm Tm balance | **5 °C** | `ThermoPolicy.max_tm_diff`; `FilterConfig.max_tm_diff`; `MutationConfig.max_tm_diff` | **Larsson et al. 2010** *Nat Methods* 7:395; **Krzywkowski & Nilsson 2017** — the two arms must be comparable; field practice ≤ 3–5 °C. |
+| Tm proximity falloff | **20 °C** | `ThermoPolicy.tm_falloff_c` | Deliberately wide: hybrid-Tm model error is a few °C (Banerjee 2020 reports 1.1 °C at best), so a narrow falloff would rank on noise. |
+
+**Impact of R4 (balance 10 → 5 °C).** Measured before changing anything, on 232
+shipped probes at the corrected buffer: as a **hard gate**, 5 °C rejects **17.7 %**
+(19.7 % of cDNA, 3.4 % of dRNA); 10 °C rejects 0.9 %. So the tolerance tightened
+as a **scoring reference** and the gate became soft
+(`enforce_tm_diff_gate = False`, matching `enforce_tm_gate`) — ranking gains the
+discrimination field practice asks for, and no probe is discarded. Set
+`enforce_tm_diff_gate = True` for a hard cutoff.
+(`experiments/20260717_tm_buffer_config_impl/output/phase3_summary.txt`)
+
+### 5b. Target accessibility — `chemistry.FoldingConditions` (2026-07-21)
+
+Accessibility asks whether a candidate window is *open* in the folded transcript
+(local RNAplfold `p_unpaired`, Lange 2012), which beats a per-window self-fold
+MFE and puts us ahead of MERFISH/Xenium (they filter only *probe* self-structure).
+The geometry that question is asked over used to be three loose numbers repeated
+across `FilterConfig`, `search_strategies`, `annotate`, `accessibility` and two
+YAMLs — the same duplication the buffer had before `ReactionConditions`, with the
+same consequence: `build_canonical_genome_annotations` silently ignored the
+caller's geometry, and the filter folded at a nominal 37 °C while the annotation
+writer folded at the solvent-effective temperature, so the two disagreed about
+the same transcript.
+
+| Parameter | Value | Set at | Source |
+|---|---|---|---|
+| Span `L` | **100 nt** | `FoldingConditions.span`; `FilterConfig.plfold_span` | **Lange et al. 2012**, *NAR* 40:5215 — the ViennaRNA `W = L = 70` default is artifact-prone; recommended `L ≈ 100`. |
+| Window `W` | **150 nt** (`= L + 50`) | `FoldingConditions.window`; `FilterConfig.plfold_window` | Lange 2012, `W = L + 50`. |
+| Folding temperature | **tracks the reaction** (`effective_celsius` ≈ 55 °C) | `FoldingConditions.temperature_c = None`; `FilterConfig.plfold_temperature` | Folding must happen in the same buffer the arm anneals in; `None` means "derive", so the accessibility that *filters* is the accessibility that gets *annotated*. Pin a number to decouple. |
+| Aggregation | mean `p_unpaired` over the arm footprint, expression-weighted across isoforms | `accessibility.mean_open_probability` / `aggregate_open_probability` | Lange 2012 (average over the footprint). |
+
+**Impact of R9 (`W=70,L=40` → `W=150,L=100`).** On 5 real transcripts the old
+geometry **over-stated** mean `p_unpaired` by **0.10** (0.64 → 0.54), with
+|Δ| > 0.1 at **half** of all bases — a span shorter than the real base-pair
+distance cannot represent a long-range stem, so a site locked behind one reads
+as open. Gate impact is negligible (**0.1 %** of 40-nt windows cross a 0.30
+accessibility gate), and the gate is off by default (`min_accessibility = 0`).
+`FoldingConditions.signature()` keys the geometry as well as the temperature, so
+profiles computed under different `W`/`L` cannot collide in a cache or an
+annotation directory.
+(`experiments/20260717_tm_buffer_config_impl/output/phase3_summary.txt`)
 
 ## 7. Tm as a reference annotation
 
@@ -163,3 +224,13 @@ window anchor (a junction-spanning arm is annotated at its anchor, not split).
 Biopython **1.85** · primer3-py **2.3.0** · ViennaRNA **2.7.0** · NUPACK **4.0.1.8**.
 Biopython changed its default `saltcorr` (5→0) across versions, so it is **set
 explicitly** everywhere (never relied on as a default).
+
+**Declaration (R10, 2026-07-21).** `primer3-py` backs the cross-ligation screen
+and the panel orthogonality screen — both production paths that import it
+unguarded — but was declared in neither `requirements.txt` nor `pyproject.toml`,
+so a fresh install only worked if the environment happened to provide it. It is
+now a hard dependency (`primer3-py>=2.0.0`) in both. `tests/unit/test_packaging_deps.py`
+lints the *class* of bug (imported-but-undeclared) across the thermodynamic
+libraries rather than re-asserting this one case. NUPACK stays undeclared on
+purpose: it needs academic registration and a manual install, and every call
+site is gated behind `has_nupack()`.

--- a/probe_designer/annotate.py
+++ b/probe_designer/annotate.py
@@ -20,19 +20,14 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-from probe_designer.chemistry import ReactionConditions
+from probe_designer.chemistry import FoldingConditions, ReactionConditions
 from probe_designer.filtering.thermo_profile import compute_tm_profile, write_bedgraph
 
 try:
-    from probe_designer.filtering.accessibility import (
-        DEFAULT_SPAN,
-        DEFAULT_WINDOW,
-        compute_plfold_profile,
-    )
+    from probe_designer.filtering.accessibility import compute_plfold_profile
     _HAS_ACCESSIBILITY = True
 except ImportError:  # ViennaRNA missing
     _HAS_ACCESSIBILITY = False
-    DEFAULT_WINDOW, DEFAULT_SPAN = 70, 40
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +43,7 @@ def build_reference_annotations(
     chrom: Optional[str] = None,
     start: int = 0,
     accessibility: bool = True,
-    plfold_window: int = DEFAULT_WINDOW,
-    plfold_span: int = DEFAULT_SPAN,
+    folding: Optional[FoldingConditions] = None,
 ) -> List[Path]:
     """Write the first-batch thermodynamic annotation tracks for one reference.
 
@@ -64,7 +58,8 @@ def build_reference_annotations(
         chrom: bedGraph chrom column (defaults to ``reference_id``).
         start: 0-based reference offset of ``seq[0]`` (for genomic placement).
         accessibility: also write the RNAplfold accessibility track.
-        plfold_window, plfold_span: RNAplfold W / L.
+        folding: RNAplfold geometry + temperature; defaults to the Lange 2012
+            geometry folding at the reaction's solvent-effective temperature.
 
     Returns:
         Paths of the tracks written.
@@ -72,6 +67,7 @@ def build_reference_annotations(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     chrom = chrom or reference_id
+    folding = folding or FoldingConditions()
     sig = reaction.signature()
     written: List[Path] = []
 
@@ -87,11 +83,11 @@ def build_reference_annotations(
         if not _HAS_ACCESSIBILITY:
             logger.warning("ViennaRNA not available; skipping accessibility track")
         else:
-            eff_t = reaction.effective_celsius
-            acc = compute_plfold_profile(
-                seq, window=plfold_window, span=plfold_span, temperature=eff_t,
+            acc = compute_plfold_profile(seq, **folding.plfold_kwargs(reaction))
+            acc_path = (
+                out_dir
+                / f"{reference_id}_accessibility_{folding.signature(reaction)}.bedgraph"
             )
-            acc_path = out_dir / f"{reference_id}_accessibility_T{eff_t:g}.bedgraph"
             write_bedgraph(
                 acc, chrom, start, acc_path,
                 track_name=f"{reference_id}_accessibility",
@@ -111,6 +107,7 @@ def build_canonical_genome_annotations(
     arm_length: int = 20,
     chemistry: str = "dRNA",
     accessibility: bool = True,
+    folding: Optional[FoldingConditions] = None,
     gene: Optional[str] = None,
 ) -> List[Path]:
     """Genome-coordinate bedGraph tracks for ONE (canonical) transcript.
@@ -133,6 +130,7 @@ def build_canonical_genome_annotations(
     strand = int(iso.get("strand", 1))
     chrom = str(iso.get("seq_region_name") or iso.get("display_name") or "chr")
     label = gene or iso.get("display_name") or "gene"
+    folding = folding or FoldingConditions()
     sig = reaction.signature()
     written: List[Path] = []
 
@@ -145,8 +143,10 @@ def build_canonical_genome_annotations(
     written.append(tm_path)
 
     if accessibility and _HAS_ACCESSIBILITY:
-        acc = compute_plfold_profile(seq, temperature=reaction.effective_celsius)
-        acc_path = out_dir / f"{label}_accessibility_T{reaction.effective_celsius:g}.genome.bedgraph"
+        acc = compute_plfold_profile(seq, **folding.plfold_kwargs(reaction))
+        acc_path = (
+            out_dir / f"{label}_accessibility_{folding.signature(reaction)}.genome.bedgraph"
+        )
         write_genome_bedgraph(
             project_profile_to_genome(acc, exons, strand), chrom, acc_path,
             track_name=f"{label}_accessibility",
@@ -164,6 +164,7 @@ def emit_annotations_for_sequences(
     arm_length: int = 20,
     chemistry: str = "dRNA",
     accessibility: bool = True,
+    folding: Optional[FoldingConditions] = None,
 ) -> List[Path]:
     """Write annotation tracks for many references (``{reference_id: seq}``).
 
@@ -178,7 +179,7 @@ def emit_annotations_for_sequences(
         written.extend(build_reference_annotations(
             seq, str(reference_id), reaction,
             out_dir=out_dir, arm_length=arm_length,
-            chemistry=chemistry, accessibility=accessibility,
+            chemistry=chemistry, accessibility=accessibility, folding=folding,
         ))
     return written
 

--- a/probe_designer/chemistry.py
+++ b/probe_designer/chemistry.py
@@ -25,7 +25,7 @@ Tm-domain and ΔG-domain treatments consistent.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional
 
 from Bio.SeqUtils import MeltingTemp as mt
 
@@ -275,3 +275,86 @@ class ReactionConditions:
             f"_st{self.strand_nM:g}_fa{self.formamide_pct:g}"
             f"_fd{self.formamide_deg_per_pct:g}_sc{self.saltcorr}{sv}"
         )
+
+
+# ViennaRNA's own convention when no reaction context is available. Real runs
+# pass a ReactionConditions and fold at its solvent-effective temperature.
+DEFAULT_FOLD_TEMPERATURE_C = 37.0
+
+
+@dataclass(frozen=True)
+class FoldingConditions:
+    """RNAplfold window geometry + temperature for target-accessibility profiles.
+
+    The companion of :class:`ReactionConditions` for the structure side: where
+    that object answers "what buffer does the arm anneal in", this one answers
+    "over how much sequence context, and at what temperature, do we ask whether
+    the site is open".
+
+    Geometry defaults follow Lange 2012 (NAR 40:5215), which shows ViennaRNA's
+    W = L = 70 default is artifact-prone for accessibility: a span shorter than
+    the real base-pair distance cannot represent a long-range stem, so a site
+    locked behind one reads as open. The recommendation is L ~ 100 with
+    W = L + 50. (Pre-2026-07-21 this package used W = 70, L = 40 — shorter still.)
+
+    Attributes:
+        window: RNAplfold ``W``, the sliding window size (nt).
+        span: RNAplfold ``L``, the maximum base-pair span within the window (nt).
+            Must not exceed ``window``.
+        temperature_c: Folding temperature (C). ``None`` (default) means *track
+            the reaction* — resolved to :attr:`ReactionConditions.effective_celsius`
+            so the accessibility used to filter candidates is the same
+            accessibility written into the reference annotation. Set a number to
+            pin it independently of the buffer.
+    """
+
+    window: int = 150
+    span: int = 100
+    temperature_c: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        """Validate the geometry, failing fast with an actionable message."""
+        if self.window <= 0:
+            raise ValueError(f"window (W) must be > 0, got {self.window}")
+        if self.span <= 0:
+            raise ValueError(f"span (L) must be > 0, got {self.span}")
+        if self.span > self.window:
+            raise ValueError(
+                f"span (L={self.span}) must not exceed window (W={self.window}); "
+                "RNAplfold cannot pair further apart than the window it sees"
+            )
+
+    def temperature_for(self, reaction: Optional["ReactionConditions"] = None) -> float:
+        """Resolve the folding temperature against a reaction (C).
+
+        An explicit ``temperature_c`` always wins; otherwise the reaction's
+        solvent-effective temperature is used, falling back to the bare
+        ViennaRNA convention when no reaction is supplied.
+        """
+        if self.temperature_c is not None:
+            return float(self.temperature_c)
+        if reaction is not None:
+            return reaction.effective_celsius
+        return DEFAULT_FOLD_TEMPERATURE_C
+
+    def plfold_kwargs(self, reaction: Optional["ReactionConditions"] = None) -> dict:
+        """Keyword arguments for ``filtering.accessibility.compute_plfold_profile``.
+
+        Mirrors :meth:`ReactionConditions.tm_nn_kwargs` — splat it into the
+        primitive so callers never hand-carry the geometry triple again.
+        """
+        return {
+            "window": self.window,
+            "span": self.span,
+            "temperature": self.temperature_for(reaction),
+        }
+
+    def signature(self, reaction: Optional["ReactionConditions"] = None) -> str:
+        """Compact, filesystem-safe key of everything that changes the profile.
+
+        The geometry belongs in the key, not just the temperature: widening the
+        span shifts mean p_unpaired by ~0.10 on real transcripts, so two runs
+        with different W/L must not collide in a cache or an annotation
+        directory. Mirrors :meth:`ReactionConditions.signature`.
+        """
+        return f"W{self.window}_L{self.span}_T{self.temperature_for(reaction):g}"

--- a/probe_designer/cli/score.py
+++ b/probe_designer/cli/score.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import typer
 
+from probe_designer.policy import DEFAULT_POLICY, ThermoPolicy
 from probe_designer.scoring import compute_target_score, peak_rank
 
 
@@ -27,8 +28,14 @@ def score(
         None, "--output", "-o",
         help="Output JSON path. Defaults to <input>.scored.json"
     ),
-    min_arm_tm: float = typer.Option(50.0, "--min-arm-tm", help="Tm proximity target for scoring."),
-    max_tm_diff: float = typer.Option(10.0, "--max-tm-diff", help="Max Tm diff for balance scoring."),
+    min_arm_tm: float = typer.Option(
+        DEFAULT_POLICY.min_arm_tm, "--min-arm-tm",
+        help="Tm proximity target for scoring (reaction temp + margin).",
+    ),
+    max_tm_diff: float = typer.Option(
+        DEFAULT_POLICY.max_tm_diff, "--max-tm-diff",
+        help="Two-arm Tm balance tolerance for scoring.",
+    ),
     region_size: int = typer.Option(80, "--region-size", help="bp window for peak_rank grouping."),
     min_gap: int = typer.Option(40, "--min-gap", help="Minimum gap within a peak_rank region."),
 ) -> None:
@@ -37,16 +44,16 @@ def score(
     if not isinstance(data, dict):
         raise typer.BadParameter("Input JSON must be a {gene: [sites]} mapping.")
 
+    policy = ThermoPolicy(min_arm_tm=min_arm_tm, max_arm_tm=min_arm_tm + 20.0,
+                          max_tm_diff=max_tm_diff)
+
     scored: dict[str, list] = {}
     total_sites = 0
     for gene, sites in data.items():
         for site in sites:
             total_isoforms = site.get("_total_isoforms", 1)
             site["score"] = compute_target_score(
-                site,
-                min_arm_tm=min_arm_tm,
-                max_tm_diff=max_tm_diff,
-                total_isoforms=total_isoforms,
+                site, policy=policy, total_isoforms=total_isoforms,
             )
         ranked = peak_rank(sites, region_size=region_size, min_gap=min_gap)
         # Attach peak_rank index for downstream consumers

--- a/probe_designer/config/__init__.py
+++ b/probe_designer/config/__init__.py
@@ -3,7 +3,9 @@ Configuration management module
 Manages all configurable parameters for DNA probe design.
 """
 
+import dataclasses
 import os
+import warnings
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
@@ -339,6 +341,19 @@ class ConfigManager:
                     setattr(self.search, key, value)
         
         if 'filter' in config_data:
+            # Warn rather than silently discard: an unrecognised key is either a
+            # typo (`formamide_pc`) or a knob that never existed, and both used
+            # to vanish without a word. `final_probes_per_gene` lived in three
+            # shipped YAMLs that way while the real control was --top-n (R7).
+            unknown = [k for k in config_data['filter'] if not hasattr(self.filter, k)]
+            if unknown:
+                warnings.warn(
+                    f"{config_file}: ignoring unknown filter option(s) "
+                    f"{sorted(unknown)} — not a FilterConfig field. Check for a "
+                    "typo; probes-per-gene is set with --top-n, not in the config.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             for key, value in config_data['filter'].items():
                 if hasattr(self.filter, key):
                     setattr(self.filter, key, value)
@@ -398,34 +413,12 @@ class ConfigManager:
                 'window_size': getattr(self.search, 'window_size', 50),
                 'step_size': self.search.step_size
             },
-            'filter': {
-                'min_gc_content': self.filter.min_gc_content,
-                'max_gc_content': self.filter.max_gc_content,
-                'min_g_content': self.filter.min_g_content,  # deprecated
-                'max_g_content': self.filter.max_g_content,  # deprecated
-                'max_consecutive_g': self.filter.max_consecutive_g,
-                'max_consecutive_a': self.filter.max_consecutive_a,
-                'max_consecutive_t': self.filter.max_consecutive_t,
-                'max_consecutive_c': self.filter.max_consecutive_c,
-                'min_tm': self.filter.min_tm,
-                'max_tm': self.filter.max_tm,
-                'max_tm_diff': self.filter.max_tm_diff,
-                'min_free_energy': self.filter.min_free_energy,
-                'check_rna_structure': self.filter.check_rna_structure,
-                'require_specificity': self.filter.require_specificity,
-                'final_probes_per_gene': getattr(self.filter, 'final_probes_per_gene', 3),
-                # Reaction buffer (2026-07-17)
-                'monovalent_mM': self.filter.monovalent_mM,
-                'mg_mM': self.filter.mg_mM,
-                'dntp_mM': self.filter.dntp_mM,
-                'strand_nM': self.filter.strand_nM,
-                'formamide_pct': self.filter.formamide_pct,
-                'formamide_deg_per_pct': self.filter.formamide_deg_per_pct,
-                'solvents': dict(self.filter.solvents),
-                'lab_temp_c': self.filter.lab_temp_c,
-                'tm_margin_c': self.filter.tm_margin_c,
-                'saltcorr': self.filter.saltcorr,
-            },
+            # Generated from the dataclass, never hand-listed: this block used
+            # to mirror FilterConfig's fields by hand and silently dropped every
+            # field added after it was written (enforce_tm_gate, the whole
+            # RNAplfold block, max_alignments, target_organisms), so a
+            # save -> load round trip lost settings (audit R7).
+            'filter': dataclasses.asdict(self.filter),
             'blast': {
                 'blast_type': self.blast.blast_type,
                 'database': self.blast.database,

--- a/probe_designer/config/__init__.py
+++ b/probe_designer/config/__init__.py
@@ -65,13 +65,21 @@ class FilterConfig:
     # (experiments/20260717_tm_buffer_config_impl/output/impact_summary.txt).
     min_tm: float = 50.0  # min melting temperature (°C); = lab_temp_c + tm_margin_c
     max_tm: float = 70.0  # max melting temperature (°C); = lab_temp_c + 25
-    max_tm_diff: float = 10.0  # max Tm difference between 3' and 5' halves
+    # Two-arm balance. Tightened 10 -> 5 on 2026-07-21 (audit R4) to the
+    # Larsson 2010 / Krzywkowski 2017 field practice. It is a SCORING reference,
+    # not a cutoff: as a hard gate 5 C would have rejected 17.7% of 232 shipped
+    # probes (19.7% of cDNA), while as a reference it costs nothing and sharpens
+    # ranking exactly where the discrimination matters.
+    max_tm_diff: float = 5.0  # max Tm difference between 3' and 5' halves
     # 2026-07-19: the hard Tm-range gate is OFF by default. Absolute arm Tm is
     # now a SOFT scoring term (scoring.compute_target_score tm_proximity, peaked
     # at the reaction-anchored target min_tm) rather than a pass/fail cutoff, so
     # candidates rank by score instead of being dropped on Tm. min_tm/max_tm
     # remain the scoring target/reference. Set True to restore hard rejection.
+    # 2026-07-21: the balance rule joined it, for the same reason (audit R4).
+    # Both are read through policy.ThermoPolicy, shared with the ranker.
     enforce_tm_gate: bool = False
+    enforce_tm_diff_gate: bool = False
     min_free_energy: float = -10.0  # min free energy (kcal/mol)
     check_rna_structure: bool = False  # whether to check RNA secondary structure
     # --- Phase 1A: target-accessibility gate (RNAplfold) ---

--- a/probe_designer/config/__init__.py
+++ b/probe_designer/config/__init__.py
@@ -10,7 +10,7 @@ from typing import List, Dict, Any, Optional
 import json
 import yaml
 
-from probe_designer.chemistry import ReactionConditions
+from probe_designer.chemistry import FoldingConditions, ReactionConditions
 
 
 @dataclass
@@ -80,10 +80,17 @@ class FilterConfig:
     # gates each candidate window on its mean accessibility. When
     # min_accessibility == 0 (default), the legacy check_rna_structure
     # self-fold path runs instead. See filtering/accessibility.py.
+    # Geometry re-anchored 2026-07-21 (audit R9) to Lange 2012: W = L + 50 with
+    # L ~ 100. The old W=70/L=40 could not represent a base pair spanning >40 nt,
+    # so sites behind a long-range stem read as open (mean p_unpaired over-stated
+    # by ~0.10 on real transcripts). Build a FoldingConditions via
+    # folding_conditions(); see chemistry.FoldingConditions.
     min_accessibility: float = 0.0  # 0 disables; recommended 0.30 when on
-    plfold_window: int = 70         # RNAplfold W (sliding window size)
-    plfold_span: int = 40           # RNAplfold L (max bp span within window)
-    plfold_temperature: float = 37.0  # °C; raise to 47-55 to approximate formamide
+    plfold_window: int = 150        # RNAplfold W (sliding window size)
+    plfold_span: int = 100          # RNAplfold L (max bp span within window)
+    # None = track the reaction (ReactionConditions.effective_celsius), so the
+    # accessibility that filters candidates matches the reference annotation.
+    plfold_temperature: Optional[float] = None
 
     # --- Reaction buffer (2026-07-17): the real hybridization conditions used
     #     for every Tm/ΔG calculation. Flat fields so the generic YAML loader
@@ -123,6 +130,17 @@ class FilterConfig:
             lab_temp_c=self.lab_temp_c,
             tm_margin_c=self.tm_margin_c,
             saltcorr=self.saltcorr,
+        )
+
+    def folding_conditions(self) -> FoldingConditions:
+        """Materialize the flat RNAplfold fields into a FoldingConditions.
+
+        Validation (fail-fast) happens in FoldingConditions.__post_init__.
+        """
+        return FoldingConditions(
+            window=self.plfold_window,
+            span=self.plfold_span,
+            temperature_c=self.plfold_temperature,
         )
 
 

--- a/probe_designer/ext/mutation/config.py
+++ b/probe_designer/ext/mutation/config.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from probe_designer.policy import DEFAULT_MAX_TM_DIFF_C
+
 
 # Public chemistry catalog. Per-experiment overrides should mutate the dict
 # returned by :func:`default_chemistry_params` (a fresh copy each call) — never
@@ -116,7 +118,14 @@ class MutationConfig:
     g_content_range: Tuple[float, float] = (0.1, 0.9)  # DEPRECATED — informational only
     g_consecutive_max: int = 7
     mfe_min: float = -15.0
-    max_tm_diff: float = 20.0
+    # Two-arm Tm balance tolerance (C). Was 20 against the mRNA pipeline's 10;
+    # both now use the shared field-practice 5 C (Larsson 2010, Krzywkowski
+    # 2017) from policy.ThermoPolicy. This is a scoring reference — the balance
+    # gate is soft (FilterConfig.enforce_tm_diff_gate), so no probe is dropped.
+    max_tm_diff: float = DEFAULT_MAX_TM_DIFF_C
+    # Arm-length budget (NUCLEOTIDES). Distinct from max_tm_diff, which is in
+    # degrees Celsius; the two were previously the same value (audit R4/R7).
+    max_arm_len_diff: int = 20
     pad: int = 50
 
     # Numbering / backbone

--- a/probe_designer/ext/mutation/pipeline.py
+++ b/probe_designer/ext/mutation/pipeline.py
@@ -137,17 +137,23 @@ def _build_filter_config(cfg: MutationConfig, chemistry: str) -> FilterConfig:
 
 
 def _build_plp_params(cfg: MutationConfig, chemistry: str) -> Dict[str, Any]:
-    chem = cfg.chemistry_params[chemistry]
+    """Arm-geometry parameters for candidate enumeration.
+
+    Geometry only. Every thermodynamic and composition rule (Tm window, GC,
+    homopolymers, MFE) reaches the designer through :func:`_build_filter_config`
+    — one path, so a threshold cannot be set in one place and read from another.
+
+    Until 2026-07-21 this also carried G_min/G_max/G_consecutive/Tm_low/Tm_high/
+    max_Tm_dif/mfe_thre, none of which any live code read: they were consumed by
+    the legacy ``plp_evaluation`` path that FilterConfig replaced. Dead keys that
+    look live are how ``max_arm_len_dif=cfg.max_tm_diff`` — a budget in
+    nucleotides fed a tolerance in degrees Celsius — went unnoticed (audit R4/R7).
+    """
     return dict(
-        G_min=cfg.g_content_range[0], G_max=cfg.g_content_range[1],
-        G_consecutive=cfg.g_consecutive_max,
-        Tm_low=chem.tm_range[0], Tm_high=chem.tm_range[1],
-        max_Tm_dif=cfg.max_tm_diff,
-        mfe_thre=cfg.mfe_min,
         ini_arm_len=cfg.ini_arm_len,
         min_arm_len=cfg.arm_len_range[0],
         max_arm_len=cfg.arm_len_range[1],
-        max_arm_len_dif=cfg.max_tm_diff,
+        max_arm_len_diff=cfg.max_arm_len_diff,
     )
 
 

--- a/probe_designer/ext/mutation/probe.py
+++ b/probe_designer/ext/mutation/probe.py
@@ -24,6 +24,18 @@ from probe_designer.config import SearchConfig, FilterConfig, BlastConfig
 from probe_designer.filtering import SequenceFilter
 
 
+def mfe_penalty_from(free_energy: Optional[float]) -> float:
+    """Positive structure penalty from a target self-fold ΔG (lower = better).
+
+    ``free_energy`` is ``None`` whenever no ΔG was computed for the site — the
+    cDNA path and any accessibility-gated run never populate it (audit R8) — in
+    which case the term contributes nothing rather than raising on ``-None``.
+    """
+    if free_energy is None:
+        return 0.0
+    return -float(free_energy)
+
+
 class MutationProbeDesigner:
     """Designs padlock probes for mutation detection."""
     
@@ -284,8 +296,9 @@ class MutationProbeDesigner:
                 # Calculate score (lower is better)
                 tm_diff = abs(thermal_result['tm_5prime'] - thermal_result['tm_3prime'])
                 arm_len_diff = abs(arm5_len - ini_arm_len) + abs(arm3_len - ini_arm_len)
-                mfe_penalty = -thermal_result['free_energy']  # Convert to positive penalty
-                score = tm_diff + arm_len_diff + mfe_penalty
+                score = tm_diff + arm_len_diff + mfe_penalty_from(
+                    thermal_result['free_energy']
+                )
                 
                 candidate = {
                     'arm5_len': arm5_len,

--- a/probe_designer/ext/tcr/pipeline.py
+++ b/probe_designer/ext/tcr/pipeline.py
@@ -188,8 +188,10 @@ def _phase1_find_select(
                 tm_dev = abs(avg_tm - target_tm)  # 0 at the target, grows both ways
                 # Higher is better: less structure (mfe), balanced arms
                 # (-tm_diff), and arm Tm near the target (-tm_dev).
+                # `or 0.0`: mfe is None when ViennaRNA is unavailable (audit R8),
+                # in which case the structure term drops out rather than raising.
                 s["score"] = round(
-                    s.get("mfe", 0.0) - s.get(f"tm_diff_{chem}", 0.0) - tm_dev, 3,
+                    (s.get("mfe") or 0.0) - s.get(f"tm_diff_{chem}", 0.0) - tm_dev, 3,
                 )
                 # tm_cDNA_warning kept for downstream readers (informational)
                 s["tm_cDNA_warning"] = not (50.0 <= s["tm_cDNA"] <= 75.0)

--- a/probe_designer/ext/tcr/probe.py
+++ b/probe_designer/ext/tcr/probe.py
@@ -183,14 +183,11 @@ class TcrProbeDesigner:
             g_5 = target_seq[:arm_len].count("G") / arm_len
             g_3 = target_seq[arm_len:].count("G") / arm_len
 
-            # MFE via ViennaRNA when available; 0.0 otherwise.
-            if _HAS_VIENNARNA:
-                try:
-                    _, mfe = RNA.fold(target_seq)
-                except Exception:
-                    mfe = 0.0
-            else:
-                mfe = 0.0
+            # MFE via ViennaRNA; None when unavailable (audit R8 — 0.0 would read
+            # as "unstructured" rather than "not computed"). No try/except: a
+            # ViennaRNA failure is a real problem and must surface, matching the
+            # mRNA path; the pipeline isolates it per gene.
+            mfe = RNA.fold(target_seq)[1] if _HAS_VIENNARNA else None
 
             sites.append({
                 "gene_name": name,
@@ -217,7 +214,7 @@ class TcrProbeDesigner:
                 "g_content": round((g_5 + g_3) / 2, 3),
                 "g_content_5prime": round(g_5, 3),
                 "g_content_3prime": round(g_3, 3),
-                "mfe": round(mfe, 2),
+                "mfe": None if mfe is None else round(mfe, 2),
                 # Allowed-subseq bounds (kept under cdr3_* keys for backwards
                 # compatibility with downstream Tm-landscape + xlsx readers).
                 "cdr3_start": sub_start,

--- a/probe_designer/filtering/__init__.py
+++ b/probe_designer/filtering/__init__.py
@@ -102,7 +102,11 @@ class SequenceFilter:
             'tm_3prime': 0.0,
             'tm_5prime': 0.0,
             'tm_diff': 0.0,
-            'free_energy': 0.0,
+            # None = not computed. The self-fold MFE below only runs on the
+            # legacy RNA path; on cDNA, or whenever accessibility supersedes it,
+            # there is no ΔG to report and 0.0 would read as "unstructured"
+            # (audit R8).
+            'free_energy': None,
             'has_consecutive_g': False,
             'failed_checks': [],
             'arm_3prime_length': len(arm_3prime),
@@ -217,13 +221,16 @@ class SequenceFilter:
             if not _HAS_VIENNARNA:
                 warnings.warn("ViennaRNA not installed; skipping RNA structure check")
             else:
-                try:
-                    _, mfe = RNA.fold(target_sequence)
-                    result['free_energy'] = mfe
-                    if mfe < min_free_energy:
-                        result['failed_checks'].append('rna_structure')
-                except Exception:
-                    result['failed_checks'].append('rna_structure_error')
+                # No try/except: a ViennaRNA failure here is a real problem
+                # (bad sequence, broken install) and must surface rather than
+                # be recorded as a filter result. The previous bare
+                # `except Exception` swallowed the traceback and reported it as
+                # a 'rna_structure_error' check, hiding install issues behind
+                # what looked like ordinary probe rejections.
+                _, mfe = RNA.fold(target_sequence)
+                result['free_energy'] = float(mfe)
+                if mfe < min_free_energy:
+                    result['failed_checks'].append('rna_structure')
         
         # 7. Determine if all checks passed
         result['passed'] = len(result['failed_checks']) == 0

--- a/probe_designer/filtering/__init__.py
+++ b/probe_designer/filtering/__init__.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from probe_designer.config import BlastConfig, FilterConfig
 from probe_designer.chemistry import dna_revcomp_to_rna
+from probe_designer.policy import ThermoPolicy
 
 
 logger = logging.getLogger(__name__)
@@ -68,10 +69,16 @@ class SequenceFilter:
         max_consecutive_a = kwargs.get('max_consecutive_a', getattr(self.filter_config, 'max_consecutive_a', 5))
         max_consecutive_t = kwargs.get('max_consecutive_t', getattr(self.filter_config, 'max_consecutive_t', 5))
         max_consecutive_c = kwargs.get('max_consecutive_c', getattr(self.filter_config, 'max_consecutive_c', 5))
-        min_tm = kwargs.get('min_tm', self.filter_config.min_tm)
-        max_tm = kwargs.get('max_tm', self.filter_config.max_tm)
-        max_tm_diff = kwargs.get('max_tm_diff', getattr(self.filter_config, 'max_tm_diff', 10.0))
-        enforce_tm_gate = kwargs.get('enforce_tm_gate', getattr(self.filter_config, 'enforce_tm_gate', False))
+        # Arm-Tm rules (target, balance tolerance, and whether each is a hard
+        # gate) come from one object shared with the ranker — see policy.py.
+        policy = ThermoPolicy.resolve(
+            self.filter_config,
+            min_tm=kwargs.get('min_tm'),
+            max_tm=kwargs.get('max_tm'),
+            max_tm_diff=kwargs.get('max_tm_diff'),
+            enforce_tm_gate=kwargs.get('enforce_tm_gate'),
+            enforce_tm_diff_gate=kwargs.get('enforce_tm_diff_gate'),
+        )
         min_free_energy = kwargs.get('min_free_energy', self.filter_config.min_free_energy)
         check_rna_structure = kwargs.get('check_rna_structure', getattr(self.filter_config, 'check_rna_structure', False))
         # Phase 1A: callers can pass a pre-computed per-window accessibility
@@ -188,17 +195,14 @@ class SequenceFilter:
         result['tm_5prime'] = tm_5
         result['tm_diff'] = abs(tm_5 - tm_3)
         
-        # Absolute arm Tm is a SOFT scoring term by default (see
-        # FilterConfig.enforce_tm_gate); only reject on the [min_tm, max_tm]
-        # range when the hard gate is explicitly enabled.
-        if enforce_tm_gate:
-            if not (min_tm <= tm_3 <= max_tm):
-                result['failed_checks'].append('tm_3prime_range')
-            if not (min_tm <= tm_5 <= max_tm):
-                result['failed_checks'].append('tm_5prime_range')
-        
-        # Check melting temperature difference
-        if result['tm_diff'] > max_tm_diff:
+        # Absolute arm Tm and two-arm balance are SOFT scoring terms by default
+        # (policy.enforce_tm_gate / enforce_tm_diff_gate); the policy answers
+        # True unless the corresponding hard gate is switched on.
+        if not policy.tm_range_ok(tm_3):
+            result['failed_checks'].append('tm_3prime_range')
+        if not policy.tm_range_ok(tm_5):
+            result['failed_checks'].append('tm_5prime_range')
+        if not policy.tm_balance_ok(result['tm_diff']):
             result['failed_checks'].append('tm_diff')
         
         # 6. Target accessibility / RNA structure gate.

--- a/probe_designer/filtering/accessibility.py
+++ b/probe_designer/filtering/accessibility.py
@@ -13,13 +13,19 @@ length-``len(seq)+1`` tuple of ``(_, p_unpaired_ulen1)`` rows. Index 0 is
 a placeholder; positions 1..N map to base 1..N. We expose a clean
 ``compute_plfold_profile`` returning a 0-indexed numpy array of length N.
 
+Window geometry (2026-07-21, audit R9): W and L come from
+``chemistry.FoldingConditions``, defaulting to Lange 2012's W = L + 50 with
+L ≈ 100. The previous W = 70 / L = 40 could not represent a base pair spanning
+more than 40 nt, so any site locked behind a long-range stem read as open —
+on real transcripts the shorter geometry over-states mean p_unpaired by ≈ 0.10.
+
 Experimental-conditions note: ViennaRNA defaults assume buffered conditions
-with no denaturant. Our hybridization buffer (~20% formamide, ~50 mM Na+,
-blocking tRNA, 37 °C) destabilizes RNA secondary structure — windows
-accessible at default plfold are *more* accessible in the wet-lab buffer,
-so the default gate is conservative. ``plfold_temperature`` is the only
-knob exposed; raising it to 47–55 °C is the documented re-calibration
-path if Phase 1A over-rejects probes that wet-lab confirms work.
+with no denaturant. Our hybridization buffer (~20% formamide) destabilizes RNA
+secondary structure, so folding happens at the *solvent-effective* temperature
+rather than a nominal 37 °C. ``FoldingConditions.temperature_c`` is ``None`` by
+default, meaning "track ``ReactionConditions.effective_celsius``" — this is what
+keeps the accessibility used to filter identical to the accessibility written
+into the reference annotation. Pin it to a number to decouple the two.
 
 Caching: per-(transcript_id, len, W, L, temperature) profiles are stored
 as ``.npy`` files under a caller-supplied directory. The cache key omits
@@ -34,6 +40,11 @@ from typing import Iterable, Optional, Sequence
 
 import numpy as np
 
+from probe_designer.chemistry import (
+    DEFAULT_FOLD_TEMPERATURE_C,
+    FoldingConditions,
+)
+
 try:
     import RNA  # ViennaRNA Python bindings (>= 2.7.0)
     _HAS_VIENNARNA = True
@@ -43,9 +54,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_WINDOW = 70
-DEFAULT_SPAN = 40
-DEFAULT_TEMPERATURE = 37.0
+# Single source of truth for the geometry: chemistry.FoldingConditions (audit
+# R9 / Lange 2012). These aliases stay so callers can keep importing constants,
+# but they are derived, not a second copy.
+_DEFAULTS = FoldingConditions()
+DEFAULT_WINDOW = _DEFAULTS.window
+DEFAULT_SPAN = _DEFAULTS.span
+DEFAULT_TEMPERATURE = DEFAULT_FOLD_TEMPERATURE_C
 
 
 def compute_plfold_profile(
@@ -60,11 +75,14 @@ def compute_plfold_profile(
     Args:
         seq: transcript sequence (DNA or RNA letters; U/T are equivalent for
             ViennaRNA's purposes — internally normalised).
-        window: sliding window size W (default 70). Lower for short
-            transcripts (e.g. 40 for CDR3 contexts).
-        span: maximum base-pair span L within the window (default 40).
-        temperature: folding temperature in °C (default 37.0). Raise to
-            approximate formamide-driven destabilization.
+        window: sliding window size W (default 150 = L + 50, Lange 2012).
+            Lower for short transcripts (e.g. 40 for CDR3 contexts); it is
+            clipped to ``len(seq)`` automatically.
+        span: maximum base-pair span L within the window (default 100).
+        temperature: folding temperature in °C (default 37.0, the bare
+            ViennaRNA convention). Callers with a buffer should pass
+            ``**FoldingConditions().plfold_kwargs(reaction)`` instead of
+            hand-picking this.
 
     Returns:
         ``np.ndarray`` of length ``len(seq)`` with ``p_unpaired`` ∈ [0, 1]

--- a/probe_designer/pipeline/pipeline.py
+++ b/probe_designer/pipeline/pipeline.py
@@ -27,6 +27,7 @@ from probe_designer.pipeline.hooks import (
     ProgressHook,
 )
 from probe_designer.pipeline.result import GeneResult, PipelineResult
+from probe_designer.policy import ThermoPolicy
 from probe_designer.scoring import (
     compute_target_score,
     select_score_peaks,
@@ -234,8 +235,19 @@ class Pipeline:
             return result
 
         # 3. Pre-BLAST thermal filter (strategy-agnostic)
+        #    Isolated per gene like the search and BLAST stages: the filter now
+        #    lets a ViennaRNA failure propagate instead of recording it as an
+        #    ordinary probe rejection (audit R8), and without a boundary here one
+        #    degenerate target sequence would abort an entire multi-gene run.
+        #    The error stays visible in result.errors rather than being
+        #    downgraded to a per-candidate failed_check.
         self.progress.on_stage(gene, "pre_blast", {"n_in": len(sites)})
-        filtered_by_gene = self._seq_filter.pre_blast_filter({gene: sites})
+        try:
+            filtered_by_gene = self._seq_filter.pre_blast_filter({gene: sites})
+        except Exception as exc:
+            result.errors.append(f"pre-BLAST filter failed: {exc}")
+            logger.warning("[%s] pre-BLAST filter failed: %s", gene, exc)
+            return result
         sites = filtered_by_gene.get(gene, [])
         self.progress.on_stage(gene, "pre_blast", {"n_out": len(sites)})
 

--- a/probe_designer/pipeline/pipeline.py
+++ b/probe_designer/pipeline/pipeline.py
@@ -289,6 +289,7 @@ class Pipeline:
         from probe_designer.search_strategies import IsoformAwareness
 
         reaction = self.config.filter.reaction_conditions()
+        folding = self.config.filter.folding_conditions()
         arm_len = max(1, int(self.config.search.binding_site_length) // 2)
 
         seqs: Dict[str, str] = {}
@@ -311,6 +312,7 @@ class Pipeline:
 
         written = emit_annotations_for_sequences(
             seqs, reaction, self._annotations_dir, arm_length=arm_len,
+            folding=folding,
         )
 
         # Canonical-transcript genome projection (for IGV overlay on the
@@ -325,7 +327,7 @@ class Pipeline:
                     written += build_canonical_genome_annotations(
                         canonical, seqs[cname], reaction,
                         out_dir=self._annotations_dir / "genome",
-                        arm_length=arm_len, gene=gene,
+                        arm_length=arm_len, folding=folding, gene=gene,
                     )
                 except Exception as exc:
                     logger.warning("[%s] genome-projection annotation failed: %s",

--- a/probe_designer/pipeline/pipeline.py
+++ b/probe_designer/pipeline/pipeline.py
@@ -266,8 +266,7 @@ class Pipeline:
         for site in sites:
             site["score"] = compute_target_score(
                 site,
-                min_arm_tm=self.config.filter.min_tm,
-                max_tm_diff=self.config.filter.max_tm_diff,
+                policy=ThermoPolicy.resolve(self.config.filter),
                 total_isoforms=total_isoforms,
             )
         selected = select_score_peaks(sites, min_distance=min_gap, max_n=top_n)

--- a/probe_designer/policy.py
+++ b/probe_designer/policy.py
@@ -1,0 +1,162 @@
+"""Design rules for arm thermodynamics — the contract between gate and ranker.
+
+``filtering`` decides whether a candidate is *acceptable*; ``scoring`` decides
+whether it is *good*. Both questions are asked of the same two numbers (the arm
+Tm target and the two-arm balance tolerance), but each subsystem used to keep
+its own copy, and the copies had drifted: ``scoring.compute_target_score``
+defaulted to ``min_arm_tm=50 / max_tm_diff=10`` regardless of what FilterConfig
+said, and FilterConfig's own ``min_tm`` default (45) contradicted every shipped
+YAML (50). A rule that lives in two places eventually disagrees with itself
+(audit R7).
+
+:class:`ThermoPolicy` holds those thresholds *and* the normalized 0-1 scoring
+shapes derived from them. The composite weights stay in ``scoring`` — how much
+a rule is worth relative to isoform coverage is a ranking decision, not a
+thermodynamic one — but the rule itself has exactly one definition.
+
+Gate vs score. Every rule here can be either a hard gate (reject) or a soft
+preference (rank lower, survive). Soft is the default, following the Phase 1
+decision to rank candidates rather than drop them on absolute Tm: a threshold
+chosen from the literature is a statement about what is *preferable*, and
+turning it into a cliff discards otherwise-good probes for being on the wrong
+side of a number that carries a few degrees of model error anyway. Flip
+``enforce_*`` to restore hard rejection.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Optional
+
+from probe_designer.chemistry import ReactionConditions
+
+# Width of the two-sided Tm-proximity falloff (C). An arm this far from the
+# target scores 0. Wide on purpose: hybrid-Tm model error is a few degrees, so
+# a narrow falloff would rank on noise.
+DEFAULT_TM_FALLOFF_C = 20.0
+
+# Two-arm Tm balance tolerance (C). Larsson 2010 / Krzywkowski 2017 require the
+# two arms to be comparable; field practice is <= 3-5 C, against the 10 (20 for
+# mutation) this package used. Tightening it as a *gate* would have rejected
+# 17.7% of 232 shipped probes, so it tightened as a scoring reference instead
+# (audit R4; experiments/20260717_tm_buffer_config_impl/).
+DEFAULT_MAX_TM_DIFF_C = 5.0
+
+# Upper arm-Tm bound as an offset above the target, for specificity.
+_MAX_TM_OFFSET_C = 20.0
+
+
+@dataclass(frozen=True)
+class ThermoPolicy:
+    """Arm-Tm thresholds plus their normalized scoring shapes.
+
+    Attributes:
+        min_arm_tm: Target arm Tm (C) — the reaction-anchored
+            ``lab_temp_c + tm_margin_c``. Doubles as the lower gate bound and
+            the peak of the proximity score.
+        max_arm_tm: Upper arm-Tm gate bound (C).
+        max_tm_diff: Two-arm Tm balance tolerance (C); also the width over
+            which the balance score decays to zero.
+        enforce_tm_gate: Reject arms outside ``[min_arm_tm, max_arm_tm]``.
+        enforce_tm_diff_gate: Reject probes whose arms differ by more than
+            ``max_tm_diff``.
+        tm_falloff_c: Width of the two-sided proximity falloff (C).
+    """
+
+    min_arm_tm: float = 50.0
+    max_arm_tm: float = 70.0
+    max_tm_diff: float = DEFAULT_MAX_TM_DIFF_C
+    enforce_tm_gate: bool = False
+    enforce_tm_diff_gate: bool = False
+    tm_falloff_c: float = DEFAULT_TM_FALLOFF_C
+
+    def __post_init__(self) -> None:
+        if self.max_arm_tm < self.min_arm_tm:
+            raise ValueError(
+                f"max_arm_tm ({self.max_arm_tm}) must be >= min_arm_tm "
+                f"({self.min_arm_tm})"
+            )
+        if self.tm_falloff_c <= 0:
+            raise ValueError(f"tm_falloff_c must be > 0, got {self.tm_falloff_c}")
+        if self.max_tm_diff < 0:
+            raise ValueError(f"max_tm_diff must be >= 0, got {self.max_tm_diff}")
+
+    # ---------------------------------------------------------- construction
+    @classmethod
+    def from_reaction(cls, reaction: ReactionConditions, **overrides: Any) -> "ThermoPolicy":
+        """Anchor the Tm target to a reaction's ``lab_temp_c + tm_margin_c``.
+
+        Raising the hybridization temperature raises what counts as a good arm,
+        without anyone editing a threshold.
+        """
+        target = reaction.min_arm_tm
+        base = {"min_arm_tm": target, "max_arm_tm": target + _MAX_TM_OFFSET_C}
+        base.update({k: v for k, v in overrides.items() if v is not None})
+        return cls(**base)
+
+    # FilterConfig field name -> policy field name. The only place the two
+    # vocabularies meet; FilterConfig speaks of a probe's Tm window, the policy
+    # speaks of an arm's target.
+    _CONFIG_ALIASES = {"min_tm": "min_arm_tm", "max_tm": "max_arm_tm"}
+
+    @classmethod
+    def resolve(cls, config: Any, **overrides: Any) -> "ThermoPolicy":
+        """Build from a ``FilterConfig``, applying per-call keyword overrides.
+
+        ``thermal_filter`` accepts one-off threshold overrides in ``**kwargs``;
+        this folds them in so a caller-supplied value and a config value are
+        never read through two different code paths. ``None`` overrides are
+        ignored, so ``kwargs.get(name)`` on an absent key is harmless.
+        """
+        own = {f.name for f in fields(cls)}
+        values = {}
+        for cfg_name, policy_name in cls._CONFIG_ALIASES.items():
+            if hasattr(config, cfg_name):
+                values[policy_name] = getattr(config, cfg_name)
+        for name in own:
+            if name not in values and hasattr(config, name):
+                values[name] = getattr(config, name)
+        for name, value in overrides.items():
+            if value is None:
+                continue
+            values[cls._CONFIG_ALIASES.get(name, name)] = value
+        return cls(**{k: v for k, v in values.items() if k in own})
+
+    # ------------------------------------------------------------- decisions
+    def tm_range_ok(self, arm_tm: float) -> bool:
+        """Does this arm Tm pass? Always True unless the hard gate is on."""
+        if not self.enforce_tm_gate:
+            return True
+        return self.min_arm_tm <= arm_tm <= self.max_arm_tm
+
+    def tm_balance_ok(self, tm_diff: float) -> bool:
+        """Are the arms balanced enough? Always True unless the gate is on."""
+        if not self.enforce_tm_diff_gate:
+            return True
+        return tm_diff <= self.max_tm_diff
+
+    # ---------------------------------------------------------------- scores
+    def tm_range_score(self, arm_tm: float) -> float:
+        """Proximity of an arm Tm to the target, 1.0 at the target down to 0.0.
+
+        Two-sided: an arm well below the target will not stay bound at the
+        hybridization temperature, and one well above costs specificity and
+        cross-probe Tm uniformity.
+        """
+        deviation = abs(arm_tm - self.min_arm_tm)
+        return max(0.0, 1.0 - deviation / self.tm_falloff_c)
+
+    def tm_balance_score(self, tm_diff: float) -> float:
+        """Two-arm balance, 1.0 for identical arms down to 0.0 at the tolerance."""
+        if self.max_tm_diff <= 0:
+            return 0.0
+        return max(0.0, 1.0 - tm_diff / self.max_tm_diff)
+
+
+DEFAULT_POLICY = ThermoPolicy()
+
+__all__ = [
+    "DEFAULT_MAX_TM_DIFF_C",
+    "DEFAULT_POLICY",
+    "DEFAULT_TM_FALLOFF_C",
+    "ThermoPolicy",
+]

--- a/probe_designer/scoring/__init__.py
+++ b/probe_designer/scoring/__init__.py
@@ -78,11 +78,15 @@ def compute_target_score(
     if arm3 and arm3[-1] in "GCgc":
         score += 0.5
 
+    # `free_energy` is None when no ΔG was computed for this site (audit R8) —
+    # the cDNA path and any accessibility-gated run never populate it. Absent
+    # and zero both contribute nothing, which is why the historical 0.0
+    # sentinel went unnoticed.
     # NOTE: docstring claims 'dG=0 -> 1.0 (best)' but the guard is `if mfe < 0`
-    # so mfe=0 actually contributes 0. Phase 1 characterization tests lock
+    # so a genuine mfe=0 also contributes 0. Phase 1 characterization tests lock
     # this behavior; behavior change is a separate decision.
-    mfe = site.get("free_energy", 0)
-    if mfe < 0:
+    mfe = site.get("free_energy")
+    if mfe is not None and mfe < 0:
         score += max(0.0, 1.0 - abs(mfe) / 10.0)
 
     return round(score, 3)

--- a/probe_designer/scoring/__init__.py
+++ b/probe_designer/scoring/__init__.py
@@ -9,8 +9,9 @@ Added in Phase 1:
   between selections (migrated from webapp task_runner._auto_select_top_n).
 """
 
-from typing import Dict, List, Any
+from typing import Any, Dict, List, Optional
 
+from ..policy import DEFAULT_POLICY, ThermoPolicy
 from .scorer import compute_off_target_score
 from .selection import select_score_peaks, select_top_n_with_gap
 
@@ -26,20 +27,26 @@ __all__ = [
 
 def compute_target_score(
     site: Dict[str, Any],
-    min_arm_tm: float = 50.0,
-    max_tm_diff: float = 10.0,
+    policy: Optional[ThermoPolicy] = None,
     total_isoforms: int = 1,
 ) -> float:
     """Compute composite quality score for a target region (0-10 scale).
 
-    Components (higher = better):
+    Components (higher = better) and their weights:
     1. isoform_coverage (0-3): fraction of isoforms covered
     2. blast_support (0-2): same-gene mRNA hit count (after specificity filter)
-    3. tm_proximity (0-2): arms closer to min_arm_tm preferred
+    3. tm_proximity (0-2): arm Tm near the policy target
     4. tm_balance (0-1): smaller |tm_5prime - tm_3prime|
     5. terminal_gc (0-1): G/C at padlock ligation point (arm5 5'-end, arm3 3'-end)
     6. delta_g (0-1): lower MFE = more stable = better
+
+    The weights live here; the Tm *thresholds and shapes* live on
+    :class:`~probe_designer.policy.ThermoPolicy` so the ranker and the filter
+    cannot disagree about them (audit R7). Pre-2026-07-21 this took loose
+    ``min_arm_tm`` / ``max_tm_diff`` floats that defaulted independently of
+    FilterConfig — pass ``ThermoPolicy.resolve(config)`` instead.
     """
+    policy = policy or DEFAULT_POLICY
     score = 0.0
 
     overlap = site.get("isoform_overlap_num", 1)
@@ -60,19 +67,9 @@ def compute_target_score(
     tm5 = site.get("tm_5prime", 0)
     tm3 = site.get("tm_3prime", 0)
     if tm5 > 0 and tm3 > 0:
-        avg_tm = (tm5 + tm3) / 2
-        # Two-sided proximity to the reaction-anchored target Tm
-        # (min_arm_tm = lab_temp_c + tm_margin_c). Peaks at the target and
-        # falls off in BOTH directions: too-low arms won't stay bound at the
-        # hyb temperature, too-high arms lose specificity / Tm uniformity.
-        # (Pre-2026-07-19 this was one-sided — only penalized excess above.)
-        tm_dev = abs(avg_tm - min_arm_tm)
-        tm_range = 20.0
-        score += max(0, 2.0 * (1.0 - tm_dev / tm_range))
+        score += 2.0 * policy.tm_range_score((tm5 + tm3) / 2)
 
-    tm_diff = abs(tm5 - tm3)
-    if max_tm_diff > 0:
-        score += max(0, 1.0 * (1.0 - tm_diff / max_tm_diff))
+    score += 1.0 * policy.tm_balance_score(abs(tm5 - tm3))
 
     arm5 = site.get("arm_5prime", "")
     arm3 = site.get("arm_3prime", "")

--- a/probe_designer/search_strategies.py
+++ b/probe_designer/search_strategies.py
@@ -244,9 +244,12 @@ class IsoformAwareStrategy(SearchStrategy):
         iso_profiles: Dict[str, Any] = {}
         if min_acc > 0:
             from .filtering.accessibility import compute_plfold_profile  # local import to keep startup light
-            plfold_W = int(getattr(self.filter_config, 'plfold_window', 70))
-            plfold_L = int(getattr(self.filter_config, 'plfold_span', 40))
-            plfold_T = float(getattr(self.filter_config, 'plfold_temperature', 37.0))
+            # Geometry + temperature come from the config objects, so the
+            # profile that gates candidates is byte-identical to the one the
+            # annotation writer emits for the same conditions (audit R9).
+            plfold_kwargs = self.filter_config.folding_conditions().plfold_kwargs(
+                self.filter_config.reaction_conditions()
+            )
             for iso in self.isoforms:
                 try:
                     mrna = self.awareness.get_isoform_mrna(iso)
@@ -256,7 +259,7 @@ class IsoformAwareStrategy(SearchStrategy):
                     _w.warn(f"plfold: skipping isoform {iso.get('display_name')}: {exc}")
                     continue
                 iso_profiles[iso['display_name']] = compute_plfold_profile(
-                    mrna, window=plfold_W, span=plfold_L, temperature=plfold_T,
+                    mrna, **plfold_kwargs,
                 )
 
         # Setup progress bars if requested

--- a/probe_designer/utils/__init__.py
+++ b/probe_designer/utils/__init__.py
@@ -316,54 +316,15 @@ def print_dependency_status():
         print(f"pip install {' '.join(missing)}")
 
 
-def create_config_template(output_file: str):
-    """Create a JSON config template on disk."""
-    config_template = {
-        "database": {
-            "organism": "mouse",
-            "database_type": "ensembl",
-            "coord_system_version": "GRCh38",
-            "max_retries": 3
-        },
-        "search": {
-            "binding_site_length": 40,
-            "max_binding_sites": 30,
-            "search_strategy": "exon_junction",
-            "step_size": None
-        },
-        "filter": {
-            "min_g_content": 0.4,
-            "max_g_content": 0.7,
-            "max_consecutive_g": 4,
-            "min_tm": 45.0,
-            "max_tm": 65.0,
-            "min_free_energy": -10.0,
-            "max_alignments": 5,
-            "require_specificity": True,
-            "target_organisms": ["Mus musculus", "Homo sapiens"]
-        },
-        "probe": {
-            "panel_type": "PRISM",
-            "barcode_file": None,
-            "primer_left": None,
-            "primer_right": None
-        },
-        "blast": {
-            "blast_type": "local",
-            "database": "refseq_rna",
-            "task": "megablast",
-            "evalue": 1e-5
-        },
-        "output": {
-            "output_dir": "results",
-            "create_timestamp": True,
-            "save_intermediate": True,
-            "file_formats": ["xlsx", "fasta", "json"]
-        }
-    }
-    with open(output_file, 'w', encoding='utf-8') as f:
-        json.dump(config_template, f, indent=2, ensure_ascii=False)
-    print(f"Config template saved: {output_file}")
+# `create_config_template` lived here until 2026-07-21 (audit R7). It wrote a
+# JSON config template from hand-copied literals — a third copy of the defaults
+# beside the dataclasses and configs/*.yaml, and by then a wrong one: it still
+# claimed min_tm 45 / max_tm 65 (contradicting every shipped YAML) and knew
+# nothing of the GC gate, the reaction buffer, the RNAplfold geometry or the
+# enforce_* switches added since. It had no callers anywhere in the monorepo,
+# and configs/config_template.yaml is the maintained, documented template.
+# Removed rather than regenerated from the dataclasses: one template is the fix,
+# two is the bug.
 
 
 def get_file_size_mb(file_path: str) -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "pandas",
-    "biopython",
+    "biopython>=1.78",
     "requests",
     "pyyaml",
     "tqdm",
@@ -18,6 +18,9 @@ dependencies = [
     "beautifulsoup4",
     "typer>=0.12",
     "python-dotenv>=1.0",
+    # DNA nearest-neighbor duplex energies; imported unguarded by the
+    # cross-ligation and orthogonality screens (audit R10).
+    "primer3-py>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,13 @@ ipython>=8.0.0
 # ViennaRNA is now available on Windows, Linux, and macOS
 ViennaRNA>=2.7.0
 
+# Thermodynamics — DNA nearest-neighbor (SantaLucia) duplex/dimer energies.
+# Production path: qc/cross_ligation.py (cross-ligation screen) and
+# filtering/pairwise_duplex.py (panel orthogonality). Declared 2026-07-21
+# (audit R10) — it was imported but undeclared, so a fresh install ImportError'd
+# at run time instead of failing at install time.
+primer3-py>=2.0.0
+
 # Phase 3 (2026-05-14) — scRNA-seq panel-level QC (anndata + scanpy adapters).
 # The QC core works on raw NumPy matrices without these; install only if
 # you use compute_expression_qc_from_anndata or the --scrna-seq CLI flag.

--- a/tests/unit/test_accessibility.py
+++ b/tests/unit/test_accessibility.py
@@ -58,6 +58,42 @@ class TestComputePlfoldProfile:
         assert hot.mean() > cold.mean()
 
 
+class TestWindowGeometry:
+    """Audit R9 — why the Lange 2012 geometry (W=L+50, L~100) replaced W=70/L=40.
+
+    A span shorter than the real base-pair distance cannot represent a
+    long-range stem, so the site reads as *open* when it is in fact locked.
+    That is the artifact Lange 2012 describes, and the reason the default
+    over-estimates accessibility.
+    """
+
+    # 10 nt AT + 20 nt GC stem + 30 nt AT loop + its reverse complement + 10 nt AT.
+    # Outermost pair spans 69 nt: invisible to L=40, resolvable at L=100.
+    _STEM = "GGCCGGCCGGAAGGCCGGCC"
+    _RC_STEM = "GGCCGGCCTTCCGGCCGGCC"
+    SEQ = ("ATATATATAT" + _STEM + "ATATATATATATATATATATATATATATATAT"[:30]
+           + _RC_STEM + "ATATATATAT")
+    STEM_A = slice(10, 30)
+
+    def test_short_span_overestimates_accessibility_of_a_long_range_stem(self):
+        short = compute_plfold_profile(self.SEQ, window=70, span=40)
+        lange = compute_plfold_profile(self.SEQ, window=150, span=100)
+        # The stem is paired in reality; the longer span must see it as *less* open.
+        assert lange[self.STEM_A].mean() < short[self.STEM_A].mean()
+
+    def test_defaults_use_the_lange_geometry(self):
+        """A bare call must not silently fall back to the artifact-prone default."""
+        from probe_designer.filtering.accessibility import (
+            DEFAULT_SPAN,
+            DEFAULT_WINDOW,
+        )
+
+        assert (DEFAULT_WINDOW, DEFAULT_SPAN) == (150, 100)
+        default = compute_plfold_profile(self.SEQ)
+        lange = compute_plfold_profile(self.SEQ, window=150, span=100)
+        assert np.allclose(default, lange)
+
+
 class TestMeanOpenProbability:
     def test_correct_window_average(self):
         prof = np.array([0.1, 0.2, 0.3, 0.4, 0.5])

--- a/tests/unit/test_config_roundtrip.py
+++ b/tests/unit/test_config_roundtrip.py
@@ -1,0 +1,88 @@
+"""A config must survive save -> load, and a YAML key must actually do something.
+
+Audit R7, generalized. `save_config` mirrored the `FilterConfig` fields by hand,
+so every field added since it was written silently vanished on save: the Phase 1
+`enforce_tm_gate`, the whole RNAplfold block, `max_alignments`,
+`target_organisms`. Load, meanwhile, applies `if hasattr(...)` and skips
+everything else — so an unrecognised key (a typo, or a knob that never existed)
+is discarded without a word. `final_probes_per_gene` sat in three shipped YAMLs
+that way: ignored on load, echoed back as a hardcoded 3 on save, while the real
+knob was the `--top-n` CLI option.
+
+The two tests here close the loop from both ends — nothing is lost on the way
+out, and nothing is silently ignored on the way in.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+import yaml
+
+from probe_designer.config import ConfigManager, FilterConfig
+
+SHIPPED_CONFIGS = [
+    "config_consensus.yaml",
+    "config_specific.yaml",
+    "config_single_sequence.yaml",
+    "config_template.yaml",
+]
+
+
+def _configs_dir():
+    from pathlib import Path
+    return Path(__file__).resolve().parents[2] / "configs"
+
+
+class TestRoundTrip:
+    def test_every_filter_field_survives_save_then_load(self, tmp_path):
+        cm = ConfigManager()
+        # Set every filter field to a non-default so a dropped one is visible.
+        cm.filter.enforce_tm_gate = True
+        cm.filter.enforce_tm_diff_gate = True
+        cm.filter.max_tm_diff = 3.5
+        cm.filter.plfold_window = 200
+        cm.filter.plfold_span = 120
+        cm.filter.plfold_temperature = 42.0
+        cm.filter.min_accessibility = 0.3
+        cm.filter.mg_mM = 7.5
+        cm.filter.solvents = {"dmso": 5.0}
+        cm.filter.max_alignments = 9
+
+        out = tmp_path / "roundtrip.yaml"
+        cm.save_config(str(out))
+
+        restored = ConfigManager()
+        restored.load_config(str(out))
+        assert dataclasses.asdict(restored.filter) == dataclasses.asdict(cm.filter)
+
+    def test_saved_yaml_carries_every_filter_field(self, tmp_path):
+        """Guards the specific failure: a field the hand-written dict forgot."""
+        cm = ConfigManager()
+        out = tmp_path / "full.yaml"
+        cm.save_config(str(out))
+        written = yaml.safe_load(out.read_text(encoding="utf-8"))["filter"]
+        expected = {f.name for f in dataclasses.fields(FilterConfig)}
+        assert expected - set(written) == set()
+
+
+class TestNoDeadKeys:
+    @pytest.mark.parametrize("name", SHIPPED_CONFIGS)
+    def test_shipped_yaml_filter_keys_all_map_to_a_field(self, name):
+        """A key that maps to no field is silently discarded on load."""
+        data = yaml.safe_load((_configs_dir() / name).read_text(encoding="utf-8"))
+        known = {f.name for f in dataclasses.fields(FilterConfig)}
+        unknown = set(data.get("filter") or {}) - known
+        assert not unknown, (
+            f"{name} sets filter keys that FilterConfig does not define and the "
+            f"loader therefore ignores: {sorted(unknown)}"
+        )
+
+    def test_loader_warns_instead_of_silently_dropping(self, tmp_path):
+        cfg = tmp_path / "typo.yaml"
+        cfg.write_text(
+            yaml.safe_dump({"filter": {"formamide_pc": 20.0}}), encoding="utf-8",
+        )
+        cm = ConfigManager()
+        with pytest.warns(UserWarning, match="formamide_pc"):
+            cm.load_config(str(cfg))

--- a/tests/unit/test_folding_conditions.py
+++ b/tests/unit/test_folding_conditions.py
@@ -1,0 +1,88 @@
+"""FoldingConditions — RNAplfold geometry as a first-class, reaction-linked object.
+
+Audit R9 (Lange 2012, NAR 40:5215): the ViennaRNA default W = L = 70 is
+artifact-prone for accessibility — too short a span truncates long-range pairing
+and systematically over-estimates how open a site is. The recommendation is
+L ~ 100 with W = L + 50.
+
+The window/span/temperature triple was previously three loose numbers repeated
+across FilterConfig, search_strategies, annotate, accessibility and the YAMLs —
+the same duplication the buffer had before ReactionConditions. These tests pin
+the object, its validation, and the rule that folding temperature *tracks the
+reaction* unless explicitly overridden (so the accessibility used to filter is
+the accessibility written into the reference annotation).
+"""
+from __future__ import annotations
+
+import pytest
+
+from probe_designer.chemistry import FoldingConditions, ReactionConditions
+from probe_designer.config import FilterConfig
+
+
+class TestDefaults:
+    def test_defaults_follow_lange_2012(self):
+        fc = FoldingConditions()
+        assert fc.span == 100
+        assert fc.window == fc.span + 50 == 150
+
+    def test_temperature_defaults_to_tracking_the_reaction(self):
+        assert FoldingConditions().temperature_c is None
+
+
+class TestValidation:
+    def test_span_above_window_is_rejected(self):
+        with pytest.raises(ValueError, match="span"):
+            FoldingConditions(window=50, span=100)
+
+    @pytest.mark.parametrize("kwargs", [{"window": 0}, {"span": 0}, {"window": -10}])
+    def test_non_positive_geometry_is_rejected(self, kwargs):
+        with pytest.raises(ValueError):
+            FoldingConditions(**kwargs)
+
+
+class TestPlfoldKwargs:
+    def test_temperature_tracks_the_reaction_when_unset(self):
+        rc = ReactionConditions(lab_temp_c=45.0, formamide_pct=20.0)
+        kw = FoldingConditions().plfold_kwargs(rc)
+        # 45 lab + 20% * 0.5 C/% formamide = 55 C effective
+        assert kw["temperature"] == pytest.approx(rc.effective_celsius)
+        assert kw["temperature"] == pytest.approx(55.0)
+
+    def test_explicit_temperature_overrides_the_reaction(self):
+        rc = ReactionConditions(lab_temp_c=45.0, formamide_pct=20.0)
+        kw = FoldingConditions(temperature_c=37.0).plfold_kwargs(rc)
+        assert kw["temperature"] == pytest.approx(37.0)
+
+    def test_without_a_reaction_falls_back_to_the_viennarna_convention(self):
+        kw = FoldingConditions().plfold_kwargs()
+        assert kw["temperature"] == pytest.approx(37.0)
+
+    def test_kwargs_match_compute_plfold_profile_signature(self):
+        """The mapping must be splat-able straight into the primitive."""
+        import inspect
+
+        from probe_designer.filtering.accessibility import compute_plfold_profile
+
+        params = inspect.signature(compute_plfold_profile).parameters
+        for key in FoldingConditions().plfold_kwargs():
+            assert key in params, f"{key} is not a compute_plfold_profile parameter"
+
+
+class TestFilterConfigIntegration:
+    def test_filter_config_defaults_are_lange_compliant(self):
+        cfg = FilterConfig()
+        assert (cfg.plfold_window, cfg.plfold_span) == (150, 100)
+
+    def test_filter_config_builds_folding_conditions(self):
+        cfg = FilterConfig(plfold_window=120, plfold_span=80, plfold_temperature=42.0)
+        fc = cfg.folding_conditions()
+        assert (fc.window, fc.span, fc.temperature_c) == (120, 80, 42.0)
+
+    def test_accessibility_module_constants_track_the_object(self):
+        """One source of truth: the module defaults are not a second copy."""
+        from probe_designer.filtering import accessibility
+
+        fc = FoldingConditions()
+        assert accessibility.DEFAULT_WINDOW == fc.window
+        assert accessibility.DEFAULT_SPAN == fc.span

--- a/tests/unit/test_free_energy_sentinel.py
+++ b/tests/unit/test_free_energy_sentinel.py
@@ -1,0 +1,91 @@
+"""`free_energy` distinguishes "not computed" from "computed as zero" (audit R8).
+
+The field was initialised to ``0.0`` and only overwritten inside the legacy
+``check_rna_structure`` branch, which runs solely when no pre-computed
+accessibility was supplied *and* the target is RNA. So on the cDNA path, and on
+any run using the RNAplfold accessibility gate, ``free_energy`` stayed ``0.0``
+— indistinguishable from a genuinely unstructured target, and enough to make
+the mutation score's ``mfe_penalty = -free_energy`` silently inert.
+
+``None`` is the honest sentinel: consumers can tell the two apart, and the
+numeric behaviour of every existing consumer is unchanged (both ``0.0`` and
+``None`` contribute nothing to a score).
+"""
+from __future__ import annotations
+
+import pytest
+
+from probe_designer.filtering import SequenceFilter
+from probe_designer.scoring import compute_target_score
+
+ARM_3 = "GATGATGATGATGATGATGC"
+ARM_5 = "GATGATGATGATGATGATGC"
+RNA_TARGET = "GCATCATCATCATCATCATCGCATCATCATCATCATCATC"
+
+
+@pytest.fixture
+def filt(default_filter_config, default_blast_config):
+    return SequenceFilter(default_filter_config, default_blast_config)
+
+
+class TestSentinel:
+    def test_none_when_structure_check_is_off(self, filt):
+        result = filt.thermal_filter(
+            ARM_3, ARM_5, target_sequence=RNA_TARGET, check_rna_structure=False,
+        )
+        assert result["free_energy"] is None
+
+    def test_none_when_accessibility_supersedes_the_mfe_path(self, filt):
+        """A pre-computed accessibility replaces the self-fold check entirely."""
+        result = filt.thermal_filter(
+            ARM_3, ARM_5, target_sequence=RNA_TARGET,
+            check_rna_structure=True, target_accessibility=0.8,
+        )
+        assert result["free_energy"] is None
+
+    def test_none_on_a_dna_target_even_with_the_check_on(self, filt):
+        """The MFE branch is RNA-only; cDNA never populated it."""
+        result = filt.thermal_filter(
+            ARM_3, ARM_5, target_sequence=RNA_TARGET,
+            target_type="DNA", check_rna_structure=True,
+        )
+        assert result["free_energy"] is None
+
+    def test_populated_on_the_rna_self_fold_path(self, filt):
+        pytest.importorskip("RNA")
+        result = filt.thermal_filter(
+            ARM_3, ARM_5, target_sequence=RNA_TARGET,
+            target_type="RNA", check_rna_structure=True,
+        )
+        assert isinstance(result["free_energy"], float)
+        assert result["free_energy"] <= 0.0
+
+
+class TestConsumersHandleNone:
+    """None must be inert, not a crash — and score exactly as 0.0 used to."""
+
+    def _site(self, **overrides):
+        base = {
+            "arm_5prime": "ATATATATAT", "arm_3prime": "ATATATATAT",
+            "tm_5prime": 50.0, "tm_3prime": 50.0,
+            "isoform_overlap_num": 1, "blast_alignments": [],
+        }
+        base.update(overrides)
+        return base
+
+    def test_scorer_treats_none_like_the_old_zero(self):
+        assert compute_target_score(self._site(free_energy=None)) == pytest.approx(
+            compute_target_score(self._site(free_energy=0.0))
+        )
+
+    def test_scorer_still_rewards_a_real_negative_mfe(self):
+        neutral = compute_target_score(self._site(free_energy=None))
+        structured = compute_target_score(self._site(free_energy=-5.0))
+        assert structured > neutral
+
+    def test_mutation_candidate_score_survives_none(self):
+        """ext/mutation computed `-free_energy`, which raises on None."""
+        from probe_designer.ext.mutation.probe import mfe_penalty_from
+
+        assert mfe_penalty_from(None) == 0.0
+        assert mfe_penalty_from(-4.0) == 4.0

--- a/tests/unit/test_mutation_config.py
+++ b/tests/unit/test_mutation_config.py
@@ -35,6 +35,42 @@ def test_default_chemistries_are_all_three(tmp_path):
     assert cfg.chemistries == list(ALL_CHEMISTRIES)
 
 
+def test_arm_balance_tolerance_matches_the_shared_default(tmp_path):
+    """Audit R4: mutation used 20 C against the mRNA pipeline's 10; both now
+    use the field-practice 5 C from ThermoPolicy. It is a scoring reference —
+    the balance gate is soft, so this drops no mutation probes."""
+    from probe_designer.policy import DEFAULT_MAX_TM_DIFF_C
+
+    cfg = MutationConfig(**make_kwargs(tmp_path))
+    assert cfg.max_tm_diff == DEFAULT_MAX_TM_DIFF_C
+
+
+def test_arm_length_budget_is_independent_of_the_tm_tolerance(tmp_path):
+    """Audit R4/R7: `max_arm_len_dif` used to be fed `max_tm_diff` — a value in
+    degrees Celsius spent as a budget in nucleotides. Separate knobs now, so
+    tightening the Tm tolerance cannot silently reshape probe geometry."""
+    cfg = MutationConfig(**make_kwargs(tmp_path))
+    assert cfg.max_arm_len_diff == 20
+    assert cfg.max_arm_len_diff != cfg.max_tm_diff
+
+
+def test_plp_params_carries_only_what_the_designer_reads(tmp_path):
+    """The dict is a parameter *contract*, not a dumping ground.
+
+    It used to carry eight keys (G_min, Tm_low, max_Tm_dif, mfe_thre, ...) that
+    no live code read — leftovers from the legacy `plp_evaluation` path, whose
+    job FilterConfig now does. Dead keys that look live are how a unit
+    confusion like max_arm_len_dif survives unnoticed.
+    """
+    from probe_designer.ext.mutation.pipeline import _build_plp_params
+
+    cfg = MutationConfig(**make_kwargs(tmp_path))
+    params = _build_plp_params(cfg, "iLock")
+    assert set(params) == {
+        "ini_arm_len", "min_arm_len", "max_arm_len", "max_arm_len_diff",
+    }
+
+
 def test_default_ilock_tm_range_is_50_70(tmp_path):
     """Per 2026-05-10 audit, default iLock Tm window is 50-70 (was 55-75)."""
     cfg = MutationConfig(**make_kwargs(tmp_path))

--- a/tests/unit/test_packaging_deps.py
+++ b/tests/unit/test_packaging_deps.py
@@ -1,0 +1,73 @@
+"""Every third-party library the production code imports must be declared.
+
+Audit R10 (2026-07-15): ``primer3-py`` was imported by the cross-ligation screen
+— production code — but appeared in neither ``requirements.txt`` nor
+``pyproject.toml``. It only worked because the dev env happened to have it, so a
+fresh install of the package would ImportError at run time, not install time.
+
+This is a declaration lint, not a behaviour test: it asserts the *class* of bug
+(imported-but-undeclared) stays fixed rather than re-checking one library. A
+library may be declared as a hard dependency or as a documented optional extra;
+what it may not be is invisible.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+REQUIREMENTS = (ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+# import name -> distribution name, for libraries production modules import.
+THERMO_LIBS = {
+    "primer3": "primer3-py",   # qc/cross_ligation.py, filtering/pairwise_duplex.py
+    "Bio": "biopython",        # filtering/, chemistry.py — every Tm_NN call
+    "RNA": "ViennaRNA",        # filtering/accessibility.py (optional extra)
+}
+
+
+def _declared_in_pyproject(dist: str) -> bool:
+    """True if ``dist`` appears in [project].dependencies or any extra."""
+    return re.search(rf'"{re.escape(dist)}\b', PYPROJECT, re.IGNORECASE) is not None
+
+
+def _declared_in_requirements(dist: str) -> bool:
+    """True if ``dist`` appears as an uncommented requirement line."""
+    for line in REQUIREMENTS.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if re.match(rf"{re.escape(dist)}\b", line, re.IGNORECASE):
+            return True
+    return False
+
+
+@pytest.mark.parametrize("import_name,dist", sorted(THERMO_LIBS.items()))
+def test_thermo_library_is_declared(import_name, dist):
+    assert _declared_in_pyproject(dist) or _declared_in_requirements(dist), (
+        f"{dist} (imported as `{import_name}`) is used by production code but is "
+        f"declared in neither pyproject.toml nor requirements.txt"
+    )
+
+
+def test_primer3_is_a_hard_dependency_not_only_an_extra():
+    """primer3 backs the cross-ligation + orthogonality screens — not optional."""
+    deps_block = PYPROJECT.split("[project.optional-dependencies]")[0]
+    assert "primer3-py" in deps_block, (
+        "primer3-py must be in [project].dependencies: qc/cross_ligation.py "
+        "imports it on the production path, unguarded by a has_* check"
+    )
+
+
+def test_thermo_libraries_are_lower_bounded():
+    """Pin lower bounds: Biopython changed its default saltcorr (5 -> 0)."""
+    for dist in ("biopython", "primer3-py"):
+        line = next(
+            (ln for ln in REQUIREMENTS.splitlines()
+             if re.match(rf"{re.escape(dist)}\b", ln.strip(), re.IGNORECASE)),
+            "",
+        )
+        assert ">=" in line, f"{dist} needs a lower bound in requirements.txt, got {line!r}"

--- a/tests/unit/test_pipeline_scoring_stage.py
+++ b/tests/unit/test_pipeline_scoring_stage.py
@@ -1,0 +1,91 @@
+"""`Pipeline._run_single` must actually reach its scoring stage in a test.
+
+Every test in ``test_pipeline.py`` mocks ``get_gene_sequences`` to return
+``{"sequences": {}}``, so ``_run_single`` returns at the "No reference sequence"
+guard long before search / filter / score ever run. A full-green suite therefore
+said nothing about the back half of the per-gene body — and that is exactly where
+a `ThermoPolicy` call shipped without its import, a NameError on every real
+`probe-design design` run that 634 passing tests did not notice.
+
+These tests drive a gene all the way through to selection with the DB and BLAST
+stubbed, so the scoring stage is executed rather than skipped.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from probe_designer.config import ConfigManager
+from probe_designer.pipeline import Pipeline
+
+# 240 nt of mixed-composition sequence: long enough for the single_sequence
+# strategy to slide out several candidate windows.
+TARGET = ("GATGATGATGATGATGATGCTAGCTAGCTAGCTAGCTAGCATGCATGCATGCATGCATGC"
+          "TTGACCAGTGCATTCGAAGTGGCCGGCCGGAAGGCCGGCCATATATCGCGATATATGCTA"
+          "GCATCATCATCATCATCATCGGATCCGGATCCGGATCCAAGCTTAAGCTTAAGCTTGGCC"
+          "ACGTACGTACGTACGTACGTCCGGAATTCCGGAATTCCGGTTAACCGGTTAACCGGTTAA")
+
+
+@pytest.fixture
+def pipeline_with_sequence():
+    cfg = ConfigManager()
+    cfg.database.organism = "human"
+    cfg.search.search_strategy = "single_sequence"
+    cfg.search.binding_site_length = 40
+    with patch("probe_designer.pipeline.pipeline.DatabaseInterface") as db_cls:
+        db = db_cls.return_value
+        # Shape matters: _get_sequences_for_gene keys by GENE and reads
+        # seq_data["sequence"]. Getting this wrong is why the existing tests
+        # all bail at the "No reference sequence" guard.
+        db.get_gene_sequences.return_value = {
+            "sequences": {
+                "TESTGENE": {
+                    "sequence": TARGET,
+                    # single_sequence builds a genomic_context from these four
+                    # and raises KeyError without them.
+                    "seq_region_name": "1",
+                    "start": 1_000_000,
+                    "end": 1_000_000 + len(TARGET) - 1,
+                    "strand": 1,
+                },
+            },
+        }
+        yield Pipeline(cfg)
+
+
+class TestScoringStageIsReached:
+    def test_run_single_scores_and_selects_sites(self, pipeline_with_sequence):
+        """The regression: this path NameError'd on a missing ThermoPolicy import."""
+        result = pipeline_with_sequence.run(
+            ["TESTGENE"], strategy="single_sequence", skip_blast=True,
+        )
+        gene_result = result.per_gene["TESTGENE"]
+        assert not gene_result.errors, f"pipeline reported errors: {gene_result.errors}"
+        assert gene_result.sites, "no sites survived to selection"
+        for site in gene_result.sites:
+            assert isinstance(site["score"], float)
+            assert "peak_rank" in site
+
+    def test_scores_respond_to_the_configured_policy(self, pipeline_with_sequence):
+        """Proves the config actually reaches the scorer, not just that it ran."""
+        pipeline = pipeline_with_sequence
+        baseline = pipeline.run(
+            ["TESTGENE"], strategy="single_sequence", skip_blast=True,
+        ).per_gene["TESTGENE"].sites
+
+        # Move the Tm target far from where these arms sit; proximity must drop.
+        pipeline.config.filter.min_tm = 95.0
+        pipeline.config.filter.max_tm = 115.0
+        shifted = pipeline.run(
+            ["TESTGENE"], strategy="single_sequence", skip_blast=True,
+        ).per_gene["TESTGENE"].sites
+
+        assert baseline and shifted
+        mean_base = sum(s["score"] for s in baseline) / len(baseline)
+        mean_shifted = sum(s["score"] for s in shifted) / len(shifted)
+        assert mean_shifted < mean_base, (
+            "moving the Tm target 45 C away left scores unchanged — the "
+            f"config is not reaching the scorer ({mean_base} vs {mean_shifted})"
+        )
+

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -129,11 +129,20 @@ class TestComputeTargetScoreTm:
         assert s == pytest.approx(BASE_SCORE - 1.0, abs=TOL)
 
     def test_tm_balance_linear(self):
-        # diff=5 over max_tm_diff=10 => 0.5 (vs base 1.0) => -0.5
-        # avg=52.5, excess=2.5 => tm_prox = 2*(1-0.125) = 1.75 (vs 2.0) => -0.25
-        # Net = -0.75
+        # 2026-07-21 (audit R4): the balance tolerance tightened 10 -> 5 C to
+        # match field practice (Larsson 2010, Krzywkowski 2017), so a 5 C spread
+        # now scores 0 on balance where it used to score 0.5.
+        # diff=5 over max_tm_diff=5 => 0.0 (vs base 1.0) => -1.0
+        # avg=52.5, dev=2.5 => tm_prox = 2*(1-2.5/20) = 1.75 (vs 2.0) => -0.25
+        # Net = -1.25
         s = compute_target_score(_neutral_site(tm_5prime=50.0, tm_3prime=55.0))
-        assert s == pytest.approx(BASE_SCORE - 0.75, abs=TOL)
+        assert s == pytest.approx(BASE_SCORE - 1.25, abs=TOL)
+
+    def test_tm_balance_discriminates_within_the_tolerance(self):
+        """The point of tightening: 2 C and 4 C are no longer near-identical."""
+        tight = compute_target_score(_neutral_site(tm_5prime=50.0, tm_3prime=52.0))
+        loose = compute_target_score(_neutral_site(tm_5prime=50.0, tm_3prime=54.0))
+        assert tight > loose
 
 
 class TestComputeTargetScoreTerminalGc:

--- a/tests/unit/test_thermo_policy.py
+++ b/tests/unit/test_thermo_policy.py
@@ -1,0 +1,167 @@
+"""ThermoPolicy — arm-Tm design rules shared by the gate and the ranker.
+
+Audit R4 + R7. Two problems with one root cause: ``min_tm`` and ``max_tm_diff``
+each existed twice — once in ``filtering`` (which rejects) and once in
+``scoring`` (which ranks) — and the copies had drifted (scoring defaulted
+``max_tm_diff=10`` and ``min_arm_tm=50`` independently of FilterConfig; the
+config default ``min_tm`` was 45 against the YAMLs' 50). A rule that lives in
+two places is a rule that eventually disagrees with itself.
+
+ThermoPolicy owns the thresholds *and* the 0-1 scoring shapes, so the gate and
+the ranker cannot diverge, and the composite weights stay in ``scoring`` where
+they belong.
+
+R4 proper: the balance tolerance tightens 10 -> 5 C (Larsson 2010, Krzywkowski
+2017) but becomes a *soft* rule by default. Measured on 232 shipped probes, a
+hard 5 C gate would reject 17.7% (19.7% of cDNA); the same 5 C used as a
+scoring reference costs nothing and sharpens ranking exactly where field
+practice says the discrimination matters.
+"""
+from __future__ import annotations
+
+import pytest
+
+from probe_designer.chemistry import ReactionConditions
+from probe_designer.config import FilterConfig
+from probe_designer.policy import ThermoPolicy
+
+
+class TestDefaults:
+    def test_balance_tolerance_follows_field_practice(self):
+        assert ThermoPolicy().max_tm_diff == 5.0
+
+    def test_both_tm_rules_are_soft_by_default(self):
+        policy = ThermoPolicy()
+        assert policy.enforce_tm_gate is False
+        assert policy.enforce_tm_diff_gate is False
+
+
+class TestResolveFromConfig:
+    def test_maps_filter_config_field_names(self):
+        cfg = FilterConfig(min_tm=52.0, max_tm=68.0, max_tm_diff=4.0)
+        policy = ThermoPolicy.resolve(cfg)
+        assert (policy.min_arm_tm, policy.max_arm_tm) == (52.0, 68.0)
+        assert policy.max_tm_diff == 4.0
+
+    def test_per_call_overrides_win(self):
+        cfg = FilterConfig(max_tm_diff=5.0)
+        policy = ThermoPolicy.resolve(cfg, max_tm_diff=0.5, enforce_tm_diff_gate=True)
+        assert policy.max_tm_diff == 0.5
+        assert policy.enforce_tm_diff_gate is True
+
+    def test_none_override_does_not_clobber_the_config(self):
+        """kwargs.get(...) returning None must not wipe a real config value."""
+        cfg = FilterConfig(max_tm_diff=7.0)
+        assert ThermoPolicy.resolve(cfg, max_tm_diff=None).max_tm_diff == 7.0
+
+
+class TestFromReaction:
+    def test_target_tm_tracks_the_reaction(self):
+        """Change the hyb temperature and the Tm target moves with it."""
+        cold = ThermoPolicy.from_reaction(ReactionConditions(lab_temp_c=45.0))
+        hot = ThermoPolicy.from_reaction(ReactionConditions(lab_temp_c=60.0))
+        assert cold.min_arm_tm == 50.0          # 45 + 5 margin
+        assert hot.min_arm_tm == 65.0
+        assert hot.max_arm_tm > cold.max_arm_tm
+
+
+class TestBalanceScoring:
+    def test_perfect_balance_scores_one(self):
+        assert ThermoPolicy().tm_balance_score(0.0) == pytest.approx(1.0)
+
+    def test_score_reaches_zero_at_the_tolerance(self):
+        assert ThermoPolicy(max_tm_diff=5.0).tm_balance_score(5.0) == pytest.approx(0.0)
+
+    def test_score_is_clamped_not_negative_beyond_tolerance(self):
+        assert ThermoPolicy(max_tm_diff=5.0).tm_balance_score(50.0) == 0.0
+
+    def test_tightening_the_tolerance_sharpens_discrimination(self):
+        """The R4 point: 5 C separates probes that 10 C treats as similar."""
+        loose, tight = ThermoPolicy(max_tm_diff=10.0), ThermoPolicy(max_tm_diff=5.0)
+        assert tight.tm_balance_score(2.0) < loose.tm_balance_score(2.0)
+
+    def test_zero_tolerance_disables_the_term(self):
+        assert ThermoPolicy(max_tm_diff=0.0).tm_balance_score(3.0) == 0.0
+
+
+class TestRangeScoring:
+    def test_peaks_at_the_target(self):
+        policy = ThermoPolicy(min_arm_tm=50.0)
+        assert policy.tm_range_score(50.0) == pytest.approx(1.0)
+
+    def test_two_sided_falloff(self):
+        """Too cold is as bad as too hot — the Phase 1 two-sided shape."""
+        policy = ThermoPolicy(min_arm_tm=50.0, tm_falloff_c=20.0)
+        assert policy.tm_range_score(40.0) == pytest.approx(policy.tm_range_score(60.0))
+        assert policy.tm_range_score(60.0) == pytest.approx(0.5)
+
+    def test_clamped_at_zero(self):
+        assert ThermoPolicy(min_arm_tm=50.0).tm_range_score(200.0) == 0.0
+
+
+class TestGateSemantics:
+    def test_soft_by_default_nothing_is_rejected(self):
+        policy = ThermoPolicy(max_tm_diff=5.0)
+        assert policy.tm_balance_ok(50.0) is True
+        assert policy.tm_range_ok(5.0) is True
+
+    def test_hard_gate_rejects_when_enabled(self):
+        policy = ThermoPolicy(
+            min_arm_tm=50.0, max_arm_tm=70.0, max_tm_diff=5.0,
+            enforce_tm_gate=True, enforce_tm_diff_gate=True,
+        )
+        assert policy.tm_balance_ok(6.0) is False
+        assert policy.tm_balance_ok(4.0) is True
+        assert policy.tm_range_ok(45.0) is False
+        assert policy.tm_range_ok(75.0) is False
+        assert policy.tm_range_ok(60.0) is True
+
+    def test_gate_boundary_is_inclusive(self):
+        policy = ThermoPolicy(
+            min_arm_tm=50.0, max_arm_tm=70.0, max_tm_diff=5.0,
+            enforce_tm_gate=True, enforce_tm_diff_gate=True,
+        )
+        assert policy.tm_balance_ok(5.0) is True
+        assert policy.tm_range_ok(50.0) is True
+        assert policy.tm_range_ok(70.0) is True
+
+
+class TestSingleSourceOfTruth:
+    """The regression that motivated the object: gate and ranker agreeing."""
+
+    def test_scorer_and_filter_read_the_same_tolerance(self):
+        from probe_designer.scoring import compute_target_score
+
+        cfg = FilterConfig(max_tm_diff=5.0, enforce_tm_diff_gate=True)
+        policy = ThermoPolicy.resolve(cfg)
+
+        # A probe exactly at the tolerance: scores 0 on balance, still passes.
+        site = {"arm_5prime": "ATATATATAT", "arm_3prime": "ATATATATAT",
+                "tm_5prime": 47.5, "tm_3prime": 52.5,
+                "isoform_overlap_num": 1, "blast_alignments": [], "free_energy": 0.0}
+        assert policy.tm_balance_score(5.0) == pytest.approx(0.0)
+        assert policy.tm_balance_ok(5.0) is True
+        # and the composite reflects exactly that zero, not some other tolerance
+        with_balance = compute_target_score(site, policy=ThermoPolicy(max_tm_diff=100.0))
+        without = compute_target_score(site, policy=policy)
+        assert with_balance > without
+
+    def test_filter_gate_and_scorer_agree_on_the_same_config(self):
+        """One config in, one tolerance out — for the gate and the ranker alike."""
+        from probe_designer.config import BlastConfig
+        from probe_designer.filtering import SequenceFilter
+
+        cfg = FilterConfig(max_tm_diff=5.0, enforce_tm_diff_gate=True)
+        policy = ThermoPolicy.resolve(cfg)
+        filt = SequenceFilter(cfg, BlastConfig())
+
+        # 5' arm ~ AT-rich (low Tm), 3' arm GC-rich (high Tm) -> large tm_diff.
+        result = filt.thermal_filter(
+            arm_3prime="GCGCGCGCGCGCGCGCGCGC",
+            arm_5prime="ATATATATATATATATATAT",
+            sequence_type="DNA", target_type="DNA", target_sequence=None,
+        )
+        assert result["tm_diff"] > policy.max_tm_diff
+        # The gate rejected it, and the scorer independently scores it 0.
+        assert "tm_diff" in result["failed_checks"]
+        assert policy.tm_balance_score(result["tm_diff"]) == 0.0


### PR DESCRIPTION
## Summary

**Phase 3** of the thermodynamics audit — the remaining items **R4, R7, R8, R9, R10**.

Every one of them turned out to have the *same* root cause the buffer had: **a value
duplicated across layers**. So each is fixed at the mechanism rather than the number,
and the diff is mostly consolidation.

> **Stacked on #7** (`feature/phase2-screens-primer3`). Review this diff alone;
> retarget to `main` once #6 and #7 merge.

Impact was **measured before deciding** (`experiments/20260717_tm_buffer_config_impl/measure_phase3.py`).

## What changed

**R9 — accessibility geometry is an object, and follows Lange 2012**
- New `chemistry.FoldingConditions`, the companion of `ReactionConditions` for the
  structure side. `W`/`L`/temperature were three loose numbers repeated across
  `FilterConfig`, `search_strategies`, `annotate`, `accessibility` and two YAMLs —
  and had already drifted: `build_canonical_genome_annotations` ignored the caller's
  geometry entirely, and the filter folded at a nominal 37 °C while the annotation
  writer folded at the solvent-effective temperature. Same transcript, two answers.
- Geometry `W=70/L=40` → **`W=150/L=100`** (Lange 2012, `W = L + 50`, `L ≈ 100`).
  A span shorter than the real base-pair distance cannot represent a long-range stem,
  so a site locked behind one reads as *open*.
- `temperature_c=None` means **track the reaction**, so the accessibility that filters
  candidates is the accessibility that gets annotated.
- Measured: the old geometry **over-stated** mean p_unpaired by **0.10** (0.64 → 0.54),
  with |Δ| > 0.1 at **half** of all bases. Gate impact is negligible (**0.1 %** of 40-nt
  windows cross a 0.30 gate) and the gate is off by default.

**R4 + R7 — one `ThermoPolicy` for the gate and the ranker**
- `min_tm` and `max_tm_diff` each existed **twice**: once in `filtering` (which rejects),
  once in `scoring` (which ranks). They had drifted — `compute_target_score` defaulted to
  `min_arm_tm=50 / max_tm_diff=10` regardless of `FilterConfig`, whose own `min_tm` default
  of 45 contradicted every shipped YAML's 50. That *is* R7; the numbers were the symptom.
- New `probe_designer/policy.py`: `ThermoPolicy` owns the thresholds **and** their
  normalized 0–1 scoring shapes. `scoring` keeps the composite *weights* (how much Tm
  proximity is worth against isoform coverage is a ranking decision, not a thermodynamic
  one); `filtering` keeps its per-call override surface. Neither holds a copy of the rule.
- `ThermoPolicy.from_reaction()` re-anchors the target to `lab_temp_c + tm_margin_c`, so
  **raising the hyb temperature moves what counts as a good arm without editing a threshold.**
- **R4**: balance tolerance **10 → 5 °C** (Larsson 2010, Krzywkowski 2017) — as a *scoring
  reference*. Measured first: as a **hard gate** 5 °C rejects **17.7 %** of 232 shipped
  probes (19.7 % of cDNA); at 10 °C only 0.9 %. So the gate went soft
  (`enforce_tm_diff_gate`, mirroring Phase 1's `enforce_tm_gate`) and ranking gained the
  discrimination field practice asks for, at no cost.

**R8 — `free_energy` distinguishes "not computed" from "zero"**
- It was initialised to `0.0` and only overwritten inside the legacy `check_rna_structure`
  branch, which runs solely when no accessibility was supplied *and* the target is RNA. So
  on every cDNA design and every accessibility-gated run it stayed `0.0` — indistinguishable
  from a genuinely unstructured target, and enough to make `mfe_penalty = -free_energy`
  silently inert. It is `None` now; `None` is inert exactly where `0.0` was, so **no score
  changes**. The field *is* live for iLock/dRNA, so the fix is honesty, not deletion.
- Also removes a bare `except Exception` around `RNA.fold` that recorded ViennaRNA failures
  as an `'rna_structure_error'` filter result — a broken install read as ordinary probe
  rejections, and the repo forbids swallowing tracebacks.

**R10 — declare `primer3-py`**
- It backs the cross-ligation screen and (since #7) the orthogonality screen, both importing
  it unguarded, yet was declared nowhere: a fresh install ImportError'd at run time.
  Now a hard dependency, plus a **declaration lint** over the thermodynamic libraries so the
  imported-but-undeclared *class* of bug stays fixed. NUPACK stays undeclared on purpose
  (academic registration, every call site behind `has_nupack()`).

## Latent bugs surfaced while consolidating

None of these were in the audit; they fell out of removing the duplication.

1. **A tolerance in °C spent as a budget in nucleotides.** `ext/mutation/_build_plp_params`
   fed `max_arm_len_dif=cfg.max_tm_diff`. Harmless *only* because that key and seven others
   in the dict were dead — leftovers from the legacy `plp_evaluation` path `FilterConfig`
   replaced. Separate `max_arm_len_diff` now, and the dict is trimmed to the four keys the
   designer actually reads. (Dead keys that look live are how this survived.)
2. **`save_config` lost settings.** It mirrored `FilterConfig`'s fields by hand, so every
   field added after it was written silently vanished on save — `enforce_tm_gate`, the whole
   RNAplfold block, `max_alignments`, `target_organisms`. Generated with `asdict` now.
3. **A YAML key that did nothing.** `final_probes_per_gene` sat in three shipped configs but
   is not a `FilterConfig` field, so `load_config` ignored it and `save_config` echoed a
   hardcoded `3`. Probes-per-gene is `--top-n`. The loader now **warns** on unknown filter
   keys, which also catches typos like `formamide_pc` that used to vanish into a default.
4. **A third copy of the defaults.** `utils.create_config_template` wrote a JSON template from
   hand-copied literals, still claiming `min_tm 45 / max_tm 65` and unaware of the GC gate,
   the buffer, the plfold geometry and the `enforce_*` switches. No callers anywhere in the
   monorepo, and `configs/config_template.yaml` is the maintained template → removed rather
   than regenerated. One template is the fix; two is the bug.

## Testing

`python -m pytest` → **634 passed, 1 skipped**. New tests cover the policy (thresholds,
scoring shapes, gate semantics, and that the filter and ranker agree on one config), the
folding conditions, the `free_energy` sentinel, the config round trip from both ends, and
the dependency lint. The R9 change carries a *physics* regression test — a synthetic
long-range stem that `L=40` cannot see and `L=100` can.

Verified end to end: all four shipped configs resolve to `tm[50,70] diff=5
gates=(False,False) W/L=150/100 foldT=55`, and raising `lab_temp_c` 45 → 55 moves the
arm-Tm target 50 → 60 with no threshold edited.

## Breaking

`compute_target_score(site, min_arm_tm=, max_tm_diff=)` → `compute_target_score(site,
policy=ThermoPolicy(...))`. Both in-tree callers updated; no consumer outside `designer/`.

## Deferred

**Phase 4** (R6, Banerjee 2020 physiological-salt hybrid NN table) and the mutation/TCR/pool
CLI buffer flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
