### PR TITLE
Phase 4: Banerjee 2020 hybrid NN model, opt-in; one NN-table resolver (R6)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+# 行尾统一 LF —— 仓库里存 LF，检出也是 LF。
+#
+# 不用 `text=auto` 的默认行为（按平台原生检出，Windows 得到 CRLF），是因为这些仓放在
+# 共享存储上：**同一个工作树**会被 Linux 和 Windows 同时看到，没有"各自原生"这回事。
+# 不统一的后果实测过 —— probe_design/bank 曾显示 50 个文件被修改，其中 45 个纯属行尾假象。
+* text=auto eol=lf
+
+# 二进制显式声明。text=auto 的自动探测通常够用，但这些仓里 xlsx / 图像 / 模型权重很多，
+# 一次误判就是文件损坏，不值得赌。
+*.xlsx binary
+*.xls  binary
+*.xlsm binary
+*.pptx binary
+*.docx binary
+*.pdf  binary
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.bmp  binary
+*.tif  binary
+*.tiff binary
+*.ico  binary
+*.svgz binary
+*.gz   binary
+*.bz2  binary
+*.zip  binary
+*.7z   binary
+*.npy  binary
+*.npz  binary
+*.pkl  binary
+*.pt   binary
+*.pth  binary
+*.h5   binary
+*.hdf5 binary
+*.db   binary
+*.sqlite binary
+*.ai   binary
+*.dxf  binary
+*.mat  binary
+
+# vendored 的第三方代码保持上游原样，不做行尾规范化
+**/3rdparty/** -text
+**/third_party/** -text
+**/vendor/** -text

--- a/configs/config_consensus.yaml
+++ b/configs/config_consensus.yaml
@@ -10,9 +10,18 @@ search:
   search_strategy: "isoform_consensus"
   binding_site_length: 40
   max_binding_sites: 100
-  window_size: 50
   step_size: 1
   genes_file: "path/to/your/gene_list.txt"  # Path to gene list file (can be overridden by --genes_file)
+  # Isoform crediting (2026-08-02). An isoform counts as targeted only when a
+  # contiguous run of ITS mRNA spans the ligation junction with at least
+  # min_isoform_arm_nt on each side, and a site must bind at least one
+  # protein-coding transcript of its own gene. Before this, any isoform merely
+  # OVERLAPPING the window was credited, which both inflated the coverage count
+  # and preferred windows straddling a splice boundary — six sites in the
+  # 2026-07-27 CRC panel bound no coding transcript at all. Genes with no
+  # coding transcript are exempt from the second rule (with a warning).
+  min_isoform_arm_nt: 16
+  require_protein_coding: true
 
 filter:
   # Schema-v2 (2026-05-14): gate on GC%; legacy G-only fields kept for back-compat

--- a/configs/config_single_sequence.yaml
+++ b/configs/config_single_sequence.yaml
@@ -11,7 +11,6 @@ search:
   search_strategy: "single_sequence"
   binding_site_length: 40
   max_binding_sites: 100
-  window_size: 50
   step_size: 1
   genes_file: "path/to/your/gene_list.txt"  # Path to gene list file (can be overridden by --genes_file)
 

--- a/configs/config_specific.yaml
+++ b/configs/config_specific.yaml
@@ -10,7 +10,6 @@ search:
   search_strategy: "isoform_specific"
   binding_site_length: 40
   max_binding_sites: 100
-  window_size: 50
   step_size: 1
   genes_file: "path/to/your/gene_list.txt"  # Path to gene list file (can be overridden by --genes_file)
 

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -24,7 +24,14 @@ search:
   
   # Search parameters (for single_sequence strategy)
   step_size: 1  # Step size for sliding window search (optional, only for single_sequence)
-  
+
+  # Isoform crediting (isoform_consensus / isoform_specific)
+  min_isoform_arm_nt: 16  # nt of the window that must be contiguous on EACH side of the
+                          # ligation junction in an isoform's own mRNA before that isoform
+                          # counts as targeted. 0 = credit any isoform the junction pairs on.
+  require_protein_coding: true  # drop sites that bind no protein-coding transcript of their
+                                # own gene (genes without one are exempt, with a warning)
+
   # Gene list file
   genes_file: "path/to/your/gene_list.txt"  # Path to gene list file (can be overridden by --genes_file argument)
 

--- a/docs/thermodynamics_parameters.md
+++ b/docs/thermodynamics_parameters.md
@@ -154,6 +154,44 @@ discrimination field practice asks for, and no probe is discarded. Set
 `enforce_tm_diff_gate = True` for a hard cutoff.
 (`experiments/20260717_tm_buffer_config_impl/output/phase3_summary.txt`)
 
+### 4d. Hybrid NN model choice — `nn_tables` (2026-07-21, audit R6)
+
+Which NN table applies follows from the chemistry, and that decision used to be
+written out separately in four modules (`filtering`, `filtering.thermo_profile`,
+`ext/tcr/probe`, `rt_primer`). It now lives once in `nn_tables.nn_model_for` —
+necessary, not merely tidy: adding a second hybrid model to only some call sites
+would mean a config saying `banerjee2020` while TCR quietly stayed on Sugimoto.
+
+| Model | Salt it was measured at | Selected by | Source |
+|---|---|---|---|
+| `sugimoto1995` (**default**) | 1 M NaCl | `ReactionConditions.hybrid_nn_model` | Sugimoto 1995 *Biochemistry* 34:11211 — Biopython `R_DNA_NN1`, and the default in IDT/MELTING too, so our numbers stay comparable with colleagues'. |
+| `banerjee2020` (opt-in) | **100 mM NaCl** | same | Banerjee 2020 *NAR* 48:12042, **as corrected by *NAR* 2021 49:10796**. Tm error 1.1 °C vs Sugimoto's 4.9 °C at physiological salt. |
+
+**Use the corrected table.** The 2021 correction re-derived ΔS values that had
+been computed from rounded ΔG°37, and it moves the initiation entropies
+materially (−4.9 → −6.4, −7.0 → −8.4). The original values fail the
+ΔG°37 = ΔH° − *T*ΔS° check; the corrected ones satisfy it to 0.015 kcal/mol.
+
+**Notation.** Banerjee writes both strands 5'→3' (`rAC/dGT`); Biopython keys are
+RNA 5'→3' (U written as T) over the complement read 3'→5', so the DNA dimer is
+reversed: `rAC/dGT` → `"AC/TG"`. Both the mapping and the Gibbs relation are
+enforced in `tests/unit/test_nn_tables.py` rather than trusted to transcription.
+
+**Salt reference — the trap.** Biopython's salt corrections assume the
+parameters were derived at 1 M and correct *downward*. That is right for
+Sugimoto/SantaLucia/Freier and **wrong for Banerjee**, whose parameters already
+embody 100 mM NaCl: correcting again costs **−14.5 °C** on real 20-mer arms,
+against the ≈ −4.1 °C the two models genuinely differ by (which is what the
+paper's own 4.9 °C claim predicts). So `NNModel` carries
+`reference_monovalent_mM`, and `nn_tables.melting_temperature` uses the salt
+model only for the *shift* from that reference to the actual buffer — the
+1 M over-correction is common to both terms and cancels.
+
+**Per-arm spread.** Mean disagreement is ≈ −4 °C, but per arm it ranges roughly
+−13 to +6 °C: the two studies distribute stability differently across dimers.
+Switching models therefore re-ranks candidates, it does not merely offset them —
+which is why Sugimoto stays the default and this is an explicit opt-in.
+
 ### 5b. Target accessibility — `chemistry.FoldingConditions` (2026-07-21)
 
 Accessibility asks whether a candidate window is *open* in the folded transcript

--- a/probe_designer/chemistry.py
+++ b/probe_designer/chemistry.py
@@ -129,6 +129,12 @@ class ReactionConditions:
         saltcorr: Biopython MeltingTemp salt-correction method (1-7). 5 =
             SantaLucia 1998 entropic (+ von Ahsen Mg-equivalent); 7 = Owczarzy
             2008 divalent decision tree (more accurate at high Mg2+).
+        hybrid_nn_model: Which DNA:RNA nearest-neighbor set to use —
+            ``"sugimoto1995"`` (default, the software default everywhere, so our
+            numbers stay comparable with colleagues') or ``"banerjee2020"`` (more
+            accurate at physiological salt: 1.1 C Tm error vs 4.9 C). Affects
+            only the hybrid chemistries; cDNA (DNA:DNA) and RNA:RNA are
+            unchanged. See nn_tables.
     """
 
     monovalent_mM: float = 75.0
@@ -141,6 +147,7 @@ class ReactionConditions:
     lab_temp_c: float = 45.0
     tm_margin_c: float = 5.0
     saltcorr: int = 5
+    hybrid_nn_model: str = "sugimoto1995"
 
     @classmethod
     def from_buffer(
@@ -170,6 +177,15 @@ class ReactionConditions:
         if self.saltcorr not in _VALID_SALTCORR:
             raise ValueError(
                 f"saltcorr must be one of {sorted(_VALID_SALTCORR)}, got {self.saltcorr}"
+            )
+        # Imported here: nn_tables imports nothing from this module, but keeping
+        # the dependency one-directional at module scope would still read oddly.
+        from probe_designer.nn_tables import HYBRID_MODELS
+
+        if self.hybrid_nn_model not in HYBRID_MODELS:
+            raise ValueError(
+                f"hybrid_nn_model must be one of {sorted(HYBRID_MODELS)}, "
+                f"got {self.hybrid_nn_model!r}"
             )
         for name, pct in self.solvents.items():
             if pct < 0:

--- a/probe_designer/cli/design.py
+++ b/probe_designer/cli/design.py
@@ -123,6 +123,20 @@ def design(
              "flag, all isoforms (including retained_intron, NMD, "
              "processed_transcript) participate, which can dilute consensus."
     ),
+    # --- Isoform crediting (isoform_consensus) ---
+    min_isoform_arm_nt: Optional[int] = typer.Option(
+        None, "--min-isoform-arm-nt", min=0,
+        help="An isoform counts as targeted only when a contiguous run of its "
+             "own mRNA spans the ligation junction with at least this many nt "
+             "on each side (the junction-centred core rule). Default 16. "
+             "0 credits any isoform the junction is paired on."
+    ),
+    allow_noncoding_only: bool = typer.Option(
+        False, "--allow-noncoding-only",
+        help="Keep sites that bind no protein-coding transcript of their own "
+             "gene. Off by default: such sites cannot report the gene's "
+             "expression. Genes with no coding transcript are exempt anyway."
+    ),
     # --- Reaction buffer overrides (chemistry.ReactionConditions) ---
     monovalent_mm: Optional[float] = typer.Option(
         None, "--monovalent-mm", help="Reaction monovalent K+ (mM). Default 75."
@@ -177,6 +191,10 @@ def design(
     cfg = ConfigManager(str(config_path), species=species)
     cfg.search.search_strategy = strategy.value
 
+    if min_isoform_arm_nt is not None:
+        cfg.search.min_isoform_arm_nt = min_isoform_arm_nt
+    if allow_noncoding_only:
+        cfg.search.require_protein_coding = False
     if blast_species:
         cfg.blast.species = list(blast_species)
     if genome_fasta:

--- a/probe_designer/config/__init__.py
+++ b/probe_designer/config/__init__.py
@@ -32,6 +32,21 @@ class SearchConfig:
     search_strategy: str = "isoform_consensus"  # single_sequence, isoform_consensus, isoform_specific, exon_junction
     step_size: Optional[int] = None  # step size for single_sequence strategy
     genes_file: Optional[str] = None  # path to gene list file (can be overridden by command line)
+    # --- isoform crediting (isoform_consensus only), added 2026-08-02 ---
+    # An isoform counts as targeted when a contiguous run of ITS mRNA covers the
+    # ligation junction with at least this many window nt on each side — the
+    # lab's junction-centred core rule. Before this, `isoforms_union` credited
+    # any isoform merely overlapping the window, which inflated the coverage
+    # count AND (since the count is a ranking key) preferred windows straddling
+    # a splice boundary. See probe_designer/isoform_coverage.py and
+    # experiments/20260727_CRC_BRAF_round1/DESIGNER_ISSUE_isoform_coverage.md.
+    # 16 nt is the shortest arm that holds at the lab's 37 C / 10 nM hyb.
+    min_isoform_arm_nt: int = 16
+    # Drop candidates that bind no protein-coding transcript of their own gene.
+    # Six sites in the 2026-07-27 CRC panel were built on retained-intron or
+    # Ensembl-only transcripts and hit 0 coding transcripts at full length.
+    # Ignored (with a warning) for genes that have no coding transcript at all.
+    require_protein_coding: bool = True
 
 
 @dataclass
@@ -127,6 +142,12 @@ class FilterConfig:
     max_alignments: int = 5  # max allowed alignments (specificity)
     require_specificity: bool = True  # enforce specificity in BLAST filter
     target_organisms: List[str] = None  # target organisms to allow
+    # Fraction of the probe a same-gene alignment must span to count as a real
+    # on-target hit. Added 2026-08-02: the check was identity-only, so a probe
+    # matching its own gene over 32 of its 40 nt — what a site designed on a
+    # minor isoform looks like against the canonical transcript — passed like a
+    # 40/40 one. 0.95 leaves room for a trimmed terminal mismatch.
+    min_same_gene_coverage: float = 0.95
 
     def reaction_conditions(self) -> ReactionConditions:
         """Materialize the flat buffer fields into a ReactionConditions.
@@ -341,10 +362,23 @@ class ConfigManager:
                     setattr(self.database, key, value)
         
         if 'search' in config_data:
+            # Same reasoning as the `filter` block below: a key the loader
+            # cannot map is either a typo or a knob that never existed, and
+            # both used to vanish in silence (`window_size` sat in three
+            # shipped YAMLs that way).
+            unknown = [k for k in config_data['search'] if not hasattr(self.search, k)]
+            if unknown:
+                warnings.warn(
+                    f"{config_file}: ignoring unknown search option(s) "
+                    f"{sorted(unknown)} — not a SearchConfig field. Check for a "
+                    "typo; probes-per-gene is set with --top-n, not in the config.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             for key, value in config_data['search'].items():
                 if hasattr(self.search, key):
                     setattr(self.search, key, value)
-        
+
         if 'filter' in config_data:
             # Warn rather than silently discard: an unrecognised key is either a
             # typo (`formamide_pc`) or a knob that never existed, and both used
@@ -411,13 +445,12 @@ class ConfigManager:
                 'coord_system_version': self.database.coord_system_version,
                 'max_retries': self.database.max_retries
             },
-            'search': {
-                'search_strategy': self.search.search_strategy,
-                'binding_site_length': self.search.binding_site_length,
-                'max_binding_sites': self.search.max_binding_sites,
-                'window_size': getattr(self.search, 'window_size', 50),
-                'step_size': self.search.step_size
-            },
+            # Generated from the dataclass for the same reason as `filter`
+            # below: the hand-listed version dropped every field added after it
+            # was written, and `min_isoform_arm_nt` / `require_protein_coding`
+            # are safety gates whose silent loss reverts a run to the old,
+            # over-crediting behaviour (audit R7, generalized 2026-08-02).
+            'search': dataclasses.asdict(self.search),
             # Generated from the dataclass, never hand-listed: this block used
             # to mirror FilterConfig's fields by hand and silently dropped every
             # field added after it was written (enforce_tm_gate, the whole

--- a/probe_designer/config/__init__.py
+++ b/probe_designer/config/__init__.py
@@ -118,6 +118,10 @@ class FilterConfig:
     lab_temp_c: float = 45.0           # hyb anneal temperature; arm-Tm anchor
     tm_margin_c: float = 5.0           # min arm Tm = lab_temp_c + tm_margin_c
     saltcorr: int = 5                  # Biopython salt method (5 = SantaLucia'98 + von Ahsen Mg)
+    # DNA:RNA nearest-neighbor set: "sugimoto1995" (default, the software
+    # default everywhere) or "banerjee2020" (more accurate at physiological
+    # salt). Hybrid chemistries only; see nn_tables.
+    hybrid_nn_model: str = "sugimoto1995"
 
     # Post-BLAST rules
     max_alignments: int = 5  # max allowed alignments (specificity)
@@ -140,6 +144,7 @@ class FilterConfig:
             lab_temp_c=self.lab_temp_c,
             tm_margin_c=self.tm_margin_c,
             saltcorr=self.saltcorr,
+            hybrid_nn_model=self.hybrid_nn_model,
         )
 
     def folding_conditions(self) -> FoldingConditions:

--- a/probe_designer/ext/pool/tests/test_cli_create_promote.py
+++ b/probe_designer/ext/pool/tests/test_cli_create_promote.py
@@ -99,21 +99,21 @@ def test_promote_with_order_binds_all(tmp_path):
     _write_design_pool(tmp_path, "TNBCmarker_cand_v1", ["SP369_p1", "SP369_p2"])
     result = runner.invoke(app, [
         "pool", "promote", "TNBCmarker_cand_v1",
-        "--order", "O0012_SP369_TNBCmarker_20260613",
+        "--order", "O0012_20260613",
         "--concentration", "1e-8", "--repo-root", str(tmp_path),
     ])
     assert result.exit_code == 0, result.output
     pm = PoolManifest.from_yaml(tmp_path / "pools" / "TNBCmarker_cand_v1" / "manifest.yaml")
     assert pm.kind == PoolKind.PHYSICAL.value
-    assert all(e.order_id == "O0012_SP369_TNBCmarker_20260613" for e in pm.recipe)
+    assert all(e.order_id == "O0012_20260613" for e in pm.recipe)
     assert all(e.concentration_M == 1e-8 for e in pm.recipe)
 
 
 def test_promote_auto_resolves_from_inventories(tmp_path):
     _write_registry(tmp_path, ["SP369_p1", "SP369_p2"])
     _write_design_pool(tmp_path, "TNBCmarker_cand_v1", ["SP369_p1", "SP369_p2"])
-    _write_order_inventory(tmp_path, "O0011_SP369_TNBCmarker_20260612", ["SP369_p1"])
-    _write_order_inventory(tmp_path, "O0012_SP369_TNBCmarker_20260613", ["SP369_p2"])
+    _write_order_inventory(tmp_path, "O0011_20260612", ["SP369_p1"])
+    _write_order_inventory(tmp_path, "O0012_20260613", ["SP369_p2"])
     result = runner.invoke(app, [
         "pool", "promote", "TNBCmarker_cand_v1",
         "--auto", "--concentration", "1e-8", "--repo-root", str(tmp_path),
@@ -121,8 +121,8 @@ def test_promote_auto_resolves_from_inventories(tmp_path):
     assert result.exit_code == 0, result.output
     pm = PoolManifest.from_yaml(tmp_path / "pools" / "TNBCmarker_cand_v1" / "manifest.yaml")
     binding = {e.probe_id: e.order_id for e in pm.recipe}
-    assert binding["SP369_p1"] == "O0011_SP369_TNBCmarker_20260612"
-    assert binding["SP369_p2"] == "O0012_SP369_TNBCmarker_20260613"
+    assert binding["SP369_p1"] == "O0011_20260612"
+    assert binding["SP369_p2"] == "O0012_20260613"
 
 
 def test_promote_auto_errors_on_unordered_probe(tmp_path):

--- a/probe_designer/ext/tcr/probe.py
+++ b/probe_designer/ext/tcr/probe.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 
 from Bio.SeqUtils import MeltingTemp as mt
 
+from probe_designer.nn_tables import melting_temperature, nn_model_for
 from probe_designer.chemistry import (
     ReactionConditions,
     dna_revcomp_to_rna,
@@ -100,18 +101,19 @@ class TcrProbeDesigner:
     def _tm_hybrid(self, dna_arm: str) -> float:
         """Tm of a DNA probe arm hybridizing to mRNA.
 
-        ``R_DNA_NN1`` requires the RNA (target) strand, so the DNA arm is
-        reverse-complemented to its RNA-sense before the lookup. Buffer +
-        formamide come from ``self.reaction``.
+        The hybrid table requires the RNA (target) strand, so the DNA arm is
+        reverse-complemented to its RNA-sense before the lookup. Buffer,
+        co-solvents and the choice of hybrid NN set come from ``self.reaction``,
+        so a config selecting Banerjee 2020 reaches TCR too (audit R6).
         """
-        rna = dna_revcomp_to_rna(dna_arm)
-        tm = mt.Tm_NN(rna, nn_table=mt.R_DNA_NN1, **self.reaction.tm_nn_kwargs())
-        return self.reaction.apply_formamide(tm)
+        model = nn_model_for("DNA", "RNA", self.reaction.hybrid_nn_model)
+        tm = melting_temperature(dna_revcomp_to_rna(dna_arm), model, self.reaction)
+        return self.reaction.apply_solvents(tm)
 
     def _tm_dna(self, seq: str) -> float:
-        """Tm of a DNA:DNA duplex (cDNA chemistry), ``DNA_NN4`` at the buffer."""
-        tm = mt.Tm_NN(seq, nn_table=mt.DNA_NN4, **self.reaction.tm_nn_kwargs())
-        return self.reaction.apply_formamide(tm)
+        """Tm of a DNA:DNA duplex (cDNA chemistry) at the buffer."""
+        tm = melting_temperature(seq, nn_model_for("DNA", "DNA"), self.reaction)
+        return self.reaction.apply_solvents(tm)
 
     # ------------------------------------------------------------------
     # Core scan
@@ -268,3 +270,4 @@ class TcrProbeDesigner:
                     break
         selected.sort(key=lambda x: x["st"])
         return selected
+

--- a/probe_designer/filtering/__init__.py
+++ b/probe_designer/filtering/__init__.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from probe_designer.config import BlastConfig, FilterConfig
 from probe_designer.chemistry import dna_revcomp_to_rna
+from probe_designer.nn_tables import melting_temperature, nn_model_for
 from probe_designer.policy import ThermoPolicy
 
 
@@ -255,21 +256,23 @@ class SequenceFilter:
         is applied after the nearest-neighbor Tm.
         """
         rc = self.filter_config.reaction_conditions()
-        buffer = rc.tm_nn_kwargs()
+        model = nn_model_for(sequence_type, target_type, rc.hybrid_nn_model)
+        # A DNA:RNA hybrid table needs the RNA-sense strand; the other tables
+        # take the arm as given.
+        to_table_strand = (
+            dna_revcomp_to_rna
+            if sequence_type == "DNA" and target_type == "RNA"
+            else (lambda s: s)
+        )
 
         def arm_tm(seq: str) -> float:
             try:
-                if sequence_type == "DNA" and target_type == "RNA":
-                    tm = mt.Tm_NN(dna_revcomp_to_rna(seq), nn_table=mt.R_DNA_NN1, **buffer)
-                elif sequence_type == "RNA" and target_type == "RNA":
-                    tm = mt.Tm_NN(seq, nn_table=mt.RNA_NN1, **buffer)
-                else:
-                    tm = mt.Tm_NN(seq, nn_table=mt.DNA_NN4, **buffer)
+                tm = melting_temperature(to_table_strand(seq), model, rc)
             except ValueError as exc:
                 # Ambiguous/short arm (e.g. contains N): reject via 0.0, but surface it.
                 logger.warning("Tm computation failed for %r: %s", seq, exc)
                 return 0.0
-            return rc.apply_formamide(tm)
+            return rc.apply_solvents(tm)
 
         return {
             'tm': arm_tm(arm_3prime + arm_5prime),

--- a/probe_designer/filtering/__init__.py
+++ b/probe_designer/filtering/__init__.py
@@ -914,6 +914,7 @@ class SequenceFilter:
                                 'evalue': float('inf'),
                                 'identity': 0.0,
                                 'alignment_count': 0,
+                                'query_length': None,
                                 'missing': True
                             }
             
@@ -939,6 +940,7 @@ class SequenceFilter:
                             'evalue': float('inf'),
                             'identity': 0.0,
                             'alignment_count': 0,
+                            'query_length': None,
                             'missing': True
                         }
             
@@ -992,17 +994,25 @@ class SequenceFilter:
                                 'hit_def': alignment.hit_def,
                                 'evalue': hsp.expect,
                                 'identity': hsp.identities / hsp.align_length,
+                                # How much of the probe aligned. Identity alone
+                                # cannot tell a 40/40 hit from a 32/40 one, and
+                                # that difference is exactly what a site built
+                                # on a minor isoform looks like against the
+                                # canonical transcript.
+                                'align_length': hsp.align_length,
+                                'identities': hsp.identities,
                                 'score': hsp.score,
                                 'frame': hsp.frame
                             })
                             evalues.append(hsp.expect)
                             identities.append(hsp.identities / hsp.align_length)
-                
+
                 blast_data[query_id] = {
                     'alignments': alignments,
                     'evalue': min(evalues) if evalues else float('inf'),
                     'identity': max(identities) if identities else 0.0,
-                    'alignment_count': len(alignments)
+                    'alignment_count': len(alignments),
+                    'query_length': getattr(blast_record, 'query_length', None),
                 }
             
             # print(f"Parsed {batch_records} records from batch {batch_num}")  # Reduced output
@@ -1089,12 +1099,16 @@ class SequenceFilter:
             target_organism_alignments = 0
             non_target_gene_alignments = 0
             complementarity_found = False
-            
+
             # Get target organisms from filter config, fallback to blast config species
             target_organisms = self.filter_config.target_organisms
             if target_organisms is None:
                 target_organisms = self.blast_config.species or []
-            
+
+            probe_length = len(site.get('sequence') or '') or (
+                blast_info.get('query_length') or 0
+            )
+
             for alignment in blast_info['alignments']:
                 hit_def = alignment['hit_def'].lower()
                 is_target_organism = any(org.lower() in hit_def for org in target_organisms)
@@ -1108,16 +1122,39 @@ class SequenceFilter:
                     if not is_same_gene:
                         non_target_gene_alignments += 1
                     else:
-                        # Check complementarity with target sequence
-                        if self._check_complementarity(site['sequence'], alignment):
+                        # Check complementarity with target sequence, and that
+                        # the probe aligned over (essentially) its whole length.
+                        # A partial same-gene hit means the transcript splices
+                        # part of the probe away — it is not an on-target hit.
+                        if (
+                            self._check_complementarity(site['sequence'], alignment)
+                            and self._covers_probe(alignment, probe_length)
+                        ):
                             complementarity_found = True
-            
+
             # Must have target organism alignment AND complementarity AND no non-target gene alignments
             if target_organism_alignments == 0 or not complementarity_found or non_target_gene_alignments > 0:
                 return False
-        
+
         return True
-    
+
+    def _covers_probe(self, alignment: Dict[str, Any], probe_length: int) -> bool:
+        """True when this alignment spans enough of the probe to be on-target.
+
+        Threshold is ``filter_config.min_same_gene_coverage`` (default 0.95).
+        An alignment carrying no length is NOT assumed full: the check exists
+        precisely because the missing number used to be read as "fine".
+        """
+        if probe_length <= 0:
+            return True  # nothing to measure against
+        align_length = alignment.get('align_length')
+        if align_length is None:
+            return False
+        min_coverage = getattr(
+            self.filter_config, 'min_same_gene_coverage', 0.95
+        )
+        return align_length >= min_coverage * probe_length
+
     def _check_complementarity(self, probe_sequence: str, alignment: Dict[str, Any]) -> bool:
         """Check if probe sequence is complementary to the aligned reference sequence."""
         try:

--- a/probe_designer/filtering/thermo_profile.py
+++ b/probe_designer/filtering/thermo_profile.py
@@ -17,18 +17,15 @@ import logging
 from pathlib import Path
 
 import numpy as np
-from Bio.SeqUtils import MeltingTemp as mt
 
 from probe_designer.chemistry import ReactionConditions
+from probe_designer.nn_tables import melting_temperature, nn_model_for_chemistry
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_ARM_LENGTH = 20
 
 
-def _nn_table(chemistry: str):
-    """dRNA / iLock -> DNA:RNA hybrid table; cDNA -> DNA:DNA table."""
-    return mt.DNA_NN4 if str(chemistry).lower() == "cdna" else mt.R_DNA_NN1
 
 
 def compute_tm_profile(
@@ -54,16 +51,15 @@ def compute_tm_profile(
     """
     seq = seq.upper()
     n = len(seq)
-    table = _nn_table(chemistry)
-    buffer = reaction.tm_nn_kwargs()
+    model = nn_model_for_chemistry(chemistry, reaction.hybrid_nn_model)
     out = np.full(n, np.nan, dtype=np.float64)
     for i in range(n - arm_length + 1):
         window = seq[i:i + arm_length]
         try:
-            tm = mt.Tm_NN(window, nn_table=table, **buffer)
+            tm = melting_temperature(window, model, reaction)
         except ValueError:
             continue
-        out[i] = reaction.apply_formamide(tm)
+        out[i] = reaction.apply_solvents(tm)
     return out
 
 

--- a/probe_designer/isoform_coverage.py
+++ b/probe_designer/isoform_coverage.py
@@ -1,0 +1,314 @@
+"""Which isoforms a padlock binding window can actually be ligated on.
+
+``isoform_consensus`` needs one number per candidate window: how many of the
+gene's transcripts the probe will bind. It used to answer that with
+``IsoformAwareness.isoforms_union`` — the set of isoforms owning any exon
+fragment the window OVERLAPS. That is not the same question. An isoform can
+own part of the window and still splice the rest away, and because the count is
+also a ranking key, over-crediting actively PREFERRED such windows. Six sites
+in the 2026-07-27 CRC panel bind no protein-coding transcript of their own gene
+as a result (``DESIGNER_ISSUE_isoform_coverage.md``).
+
+The condition a transcript has to meet is physical, not positional. The probe
+is one contiguous oligo whose two arms meet at the ligation junction; SplintR /
+Ampligase read that junction and will not close a nick that is not properly
+paired on both sides. So a transcript is bound only when
+
+    a *contiguous run of its own mRNA* covers the junction, with at least
+    ``min_arm`` nt of the window on each side of it.
+
+Contiguity, not mere presence, is the operative word: a retained-intron
+transcript can contain every base of a junction-spanning window and still not
+bind it, because in that mRNA the two halves are separated by the intron.
+Shortfall at the far ends of the arms is tolerated down to ``min_arm`` — the
+lab's stated rule is a junction-centred core of about +/-16 nt — because those
+bases are distal to the nick and cost affinity rather than fidelity.
+
+Coordinates are Ensembl-style: 1-based, both ends inclusive.
+"""
+from __future__ import annotations
+
+from bisect import bisect_left
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+Segment = Tuple[int, int]
+
+PROTEIN_CODING = "protein_coding"
+
+# Transcript biotypes that make a protein. `protein_coding` alone is too narrow:
+# immune-receptor genes carry their own Ensembl biotypes and NEVER appear as
+# protein_coding — TRAC and TRBC1 are TR_C_gene, IGHG1 is IG_C_gene — so a
+# protein_coding-only rule silently rejects every valid TCR/BCR constant-region
+# probe. Found by the 2026-08-02 bank audit, which flagged six good TRAC/TRBC1
+# sites as binding nothing.
+#
+# Listed explicitly rather than matched by an `IG_`/`TR_` prefix, which would
+# also admit the several hundred IG_*_pseudogene / TR_*_pseudogene entries.
+# `protein_coding_CDS_not_defined` is likewise excluded: it is what newer
+# GENCODE releases call transcripts that used to be processed_transcript, and it
+# has no CDS.
+PRODUCTIVE_BIOTYPES = frozenset({
+    PROTEIN_CODING,
+    "IG_C_gene", "IG_D_gene", "IG_J_gene", "IG_V_gene",
+    "TR_C_gene", "TR_D_gene", "TR_J_gene", "TR_V_gene",
+})
+
+
+def is_productive(biotype: str) -> bool:
+    """True when this transcript biotype makes a protein."""
+    return biotype in PRODUCTIVE_BIOTYPES
+
+
+@dataclass(frozen=True)
+class WindowCoverage:
+    """How much of one binding window survives in one isoform's mRNA.
+
+    ``lower_nt`` / ``upper_nt`` count the window bases contiguously paired on
+    the genomic-lower and genomic-upper side of the ligation junction; the arm
+    fields are the same two numbers mapped through the strand onto the padlock's
+    arms. All four are zero when the junction itself is not paired, since the
+    probe cannot be ligated on that transcript at all — ``ligatable`` says which
+    of the two zero cases you are looking at.
+    """
+
+    ligatable: bool
+    lower_nt: int
+    upper_nt: int
+    arm_3prime_nt: int
+    arm_5prime_nt: int
+
+    def credited(self, min_arm: int) -> bool:
+        """True when this isoform counts as targeted at the given bound."""
+        return (
+            self.ligatable
+            and self.lower_nt >= min_arm
+            and self.upper_nt >= min_arm
+        )
+
+
+_UNCOVERED = WindowCoverage(
+    ligatable=False, lower_nt=0, upper_nt=0, arm_3prime_nt=0, arm_5prime_nt=0
+)
+
+
+def _merge_overlaps(exons: List[Segment]) -> List[Segment]:
+    """Collapse exons that overlap; leave abutting ones alone.
+
+    A well-formed transcript has neither, but an overlap would make the exon-end
+    list non-monotonic and silently break the bisect. Abutting exons (a
+    zero-length intron) are kept separate because ``splices()`` still has to see
+    that junction.
+    """
+    merged: List[Segment] = []
+    for start, end in exons:
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(end, merged[-1][1]))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+class _ExonTrack:
+    """One isoform's exons, prepared for repeated window queries."""
+
+    __slots__ = ("name", "biotype", "exons", "_ends", "_acceptor_of")
+
+    def __init__(self, isoform: Dict[str, Any]) -> None:
+        self.name = isoform.get("display_name") or isoform.get("id") or ""
+        self.biotype = isoform.get("biotype") or ""
+        self.exons: List[Segment] = _merge_overlaps(
+            sorted((int(e["start"]), int(e["end"])) for e in isoform.get("Exon", []))
+        )
+        # Ascending because _merge_overlaps leaves no exon containing another —
+        # the bisect in pieces() depends on it.
+        self._ends = [end for _, end in self.exons]
+        # donor -> acceptor of the very next exon; the only way two window
+        # halves separated by a host intron can be adjacent in this mRNA.
+        self._acceptor_of = {
+            end: self.exons[i + 1][0] for i, (_, end) in enumerate(self.exons[:-1])
+        }
+
+    def pieces(self, start: int, end: int) -> List[Segment]:
+        """Parts of ``[start, end]`` present in this isoform, ascending.
+
+        Exons that abut in the genome are merged, since their bases are
+        adjacent in the mRNA too.
+        """
+        out: List[Segment] = []
+        for i in range(bisect_left(self._ends, start), len(self.exons)):
+            ex_start, ex_end = self.exons[i]
+            if ex_start > end:
+                break
+            lo, hi = max(ex_start, start), min(ex_end, end)
+            if lo > hi:
+                continue
+            if out and lo <= out[-1][1] + 1:
+                out[-1] = (out[-1][0], max(hi, out[-1][1]))
+            else:
+                out.append((lo, hi))
+        return out
+
+    def splices(self, donor: int, acceptor: int) -> bool:
+        """True when this isoform joins ``donor`` to ``acceptor`` exactly."""
+        return self._acceptor_of.get(donor) == acceptor
+
+
+def _junction_index(total: int, strand: int) -> int:
+    """Window index (genomic-ascending, 0-based) the ligation junction sits at.
+
+    ``arm_3prime`` is the first ``total // 2`` nt of the probe and the probe is
+    the reverse complement of the window, so arm3 pairs with the LAST
+    ``total // 2`` bases of the target. On the plus strand the target reads
+    along ascending genomic coordinates and that is the upper side; on the minus
+    strand it is the lower one.
+    """
+    return total - total // 2 if strand >= 0 else total // 2
+
+
+def window_coverage(
+    segments: Sequence[Segment],
+    exons: Sequence[Segment] | Sequence[Dict[str, Any]],
+    strand: int,
+) -> WindowCoverage:
+    """Coverage of one window by one isoform's exon structure.
+
+    ``segments`` are the window's genomic pieces in ascending order — the
+    output of ``IsoformAwareness.find_target_region``, contiguous in the HOST
+    isoform's mRNA by construction. ``exons`` is the exon list of the isoform
+    being asked about, as ``(start, end)`` pairs or Ensembl exon dicts.
+    """
+    normalized: List[Segment] = sorted(
+        (int(s), int(e)) for s, e in
+        ((x["start"], x["end"]) if isinstance(x, dict) else x for x in exons)
+    )
+    track = _ExonTrack({"Exon": [{"start": s, "end": e} for s, e in normalized]})
+    return _coverage(list(segments), track, strand)
+
+
+def _coverage(
+    segments: Sequence[Segment], track: _ExonTrack, strand: int,
+) -> WindowCoverage:
+    segs: List[Segment] = sorted((int(s), int(e)) for s, e in segments)
+    total = sum(end - start + 1 for start, end in segs)
+    if total < 2 or not track.exons:
+        return _UNCOVERED
+
+    junction = _junction_index(total, strand)
+
+    # Walk the window in genomic-ascending order, accumulating maximal runs of
+    # window positions that are contiguous in THIS isoform's mRNA.
+    runs: List[List[int]] = []
+    offset = 0
+    prev_end: Optional[int] = None
+    prev_reached_end = False
+    for index, (seg_start, seg_end) in enumerate(segs):
+        parts = track.pieces(seg_start, seg_end)
+        for part_index, (lo, hi) in enumerate(parts):
+            win_start = offset + (lo - seg_start)
+            win_end = offset + (hi - seg_start) + 1
+            joins_previous = (
+                part_index == 0
+                and index > 0
+                and lo == seg_start
+                and prev_reached_end
+                and track.splices(prev_end, seg_start)
+            )
+            if joins_previous and runs and runs[-1][1] == win_start:
+                runs[-1][1] = win_end
+            else:
+                runs.append([win_start, win_end])
+        prev_reached_end = bool(parts) and parts[-1][1] == seg_end
+        prev_end = seg_end
+        offset += seg_end - seg_start + 1
+
+    for run_start, run_end in runs:
+        if run_start < junction < run_end:
+            lower = junction - run_start
+            upper = run_end - junction
+            arm_3prime, arm_5prime = (
+                (upper, lower) if strand >= 0 else (lower, upper)
+            )
+            return WindowCoverage(
+                ligatable=True,
+                lower_nt=lower,
+                upper_nt=upper,
+                arm_3prime_nt=arm_3prime,
+                arm_5prime_nt=arm_5prime,
+            )
+    return _UNCOVERED
+
+
+class IsoformCoverageIndex:
+    """Prepared exon tracks for one gene, queried once per candidate window."""
+
+    def __init__(self, isoforms: Sequence[Dict[str, Any]]) -> None:
+        self._tracks = [_ExonTrack(iso) for iso in isoforms]
+        self._biotypes = {t.name: t.biotype for t in self._tracks}
+
+    @property
+    def biotypes(self) -> Dict[str, str]:
+        return self._biotypes
+
+    def biotype(self, isoform_name: str) -> str:
+        return self._biotypes.get(isoform_name, "")
+
+    def has_protein_coding(self) -> bool:
+        return any(is_productive(t.biotype) for t in self._tracks)
+
+    def is_productive_isoform(self, isoform_name: str) -> bool:
+        return is_productive(self.biotype(isoform_name))
+
+    def credit(
+        self, segments: Sequence[Segment], strand: int, min_arm: int,
+    ) -> Dict[str, WindowCoverage]:
+        """Isoforms this window is ligatable on, with their arm geometry."""
+        credited: Dict[str, WindowCoverage] = {}
+        for track in self._tracks:
+            coverage = _coverage(segments, track, strand)
+            if coverage.credited(min_arm):
+                credited[track.name] = coverage
+        return credited
+
+
+def credit_isoforms(
+    segments: Sequence[Segment],
+    isoforms: Sequence[Dict[str, Any]],
+    *,
+    strand: int,
+    min_arm: int,
+) -> Dict[str, WindowCoverage]:
+    """One-shot :meth:`IsoformCoverageIndex.credit` for callers without a gene."""
+    return IsoformCoverageIndex(isoforms).credit(segments, strand, min_arm)
+
+
+def coding_first(isoforms: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Protein-coding transcripts first, canonical ahead of the rest.
+
+    The search walks isoforms in order and the position-dedup keeps whichever
+    one reached a window first, so this decides which transcript a shipped probe
+    is recorded as designed against. Sorting is stable, so the provider's own
+    order survives inside each group.
+    """
+    def priority(isoform: Dict[str, Any]) -> Tuple[int, int]:
+        canonical = any(
+            isoform.get(key)
+            for key in ("is_canonical", "canonical", "mane_select")
+        )
+        coding = is_productive(isoform.get("biotype") or "")
+        return (0 if coding else 1, 0 if canonical else 1)
+
+    return sorted(isoforms, key=priority)
+
+
+__all__ = [
+    "PRODUCTIVE_BIOTYPES",
+    "PROTEIN_CODING",
+    "IsoformCoverageIndex",
+    "WindowCoverage",
+    "coding_first",
+    "credit_isoforms",
+    "is_productive",
+    "window_coverage",
+]

--- a/probe_designer/nn_tables.py
+++ b/probe_designer/nn_tables.py
@@ -1,0 +1,217 @@
+"""Nearest-neighbor parameter sets, and the one place that picks between them.
+
+Which NN table applies is decided by the chemistry — DNA:RNA hybrid for
+direct-mRNA and iLock, DNA:DNA for cDNA, RNA:RNA for an RNA probe — and that
+decision was written out separately in four modules (``filtering``,
+``filtering.thermo_profile``, ``ext.tcr.probe``, ``rt_primer``). Adding a second
+hybrid model to only some of them would have meant a config saying
+``banerjee2020`` while the TCR path quietly stayed on Sugimoto, so the mapping
+lives here once and every Tm call goes through :func:`melting_temperature`.
+
+**Salt reference — the subtle part.** Biopython's ``Tm_NN`` salt corrections
+assume the parameters were derived at 1 M Na+ and correct *downward* to the
+buffer you pass. That is right for Sugimoto 1995, SantaLucia 1998 and Freier
+1986. It is **wrong for Banerjee 2020**, whose parameters were measured *at*
+100 mM NaCl: applying the 1 M correction on top of them corrects twice. Measured
+here, that mistake costs **−14.5 °C** on real 20-mer arms, against the ≈ −4.1 °C
+the two models genuinely differ by. So a model carries the salt it was measured
+at, and :func:`melting_temperature` uses the salt model only for the *relative*
+shift from that reference to the actual buffer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from Bio.SeqUtils import MeltingTemp as mt
+
+# Banerjee et al. 2020, NAR 48:12042, Table 2 — RNA/DNA hybrid NN parameters
+# measured at 100 mM NaCl, AS CORRECTED by NAR 2021 49:10796 (the correction
+# fixed ΔS values that had been derived from rounded ΔG°37; it changes the
+# initiation entropies materially, −4.9 → −6.4 and −7.0 → −8.4).
+#
+# Notation: the paper writes both strands 5'->3' (rAC/dGT = RNA 5'-AC-3' paired
+# with DNA 5'-GT-3'). Biopython keys are RNA 5'->3' (U written as T) over the
+# *complement* read 3'->5', so the DNA dimer is reversed: rAC/dGT -> "AC/TG".
+# The mapped key set is identical to Biopython's R_DNA_NN1, and every entry
+# satisfies ΔG°37 = ΔH° − 310.15·ΔS° to within 0.015 kcal/mol (rounding only) —
+# both checked in tests/unit/test_nn_tables.py.
+#
+# Values are (ΔH° kcal/mol, ΔS° cal/(mol·K)).
+R_DNA_BANERJEE2020: Dict[str, Tuple[float, float]] = {
+    # Initiation is per terminal base pair (Biopython multiplies these by the
+    # number of terminal A/T and G/C pairs). That reading is what reproduces the
+    # paper's own claim that Sugimoto errs ≈ 4.9 °C at 100 mM; treating it as a
+    # single per-duplex term does not.
+    "init": (0.0, 0.0),
+    "init_A/T": (0.0, -8.4),      # init. rA-dT / rU-dA
+    "init_G/C": (0.0, -6.4),      # init. rG-dC / rC-dG
+    "init_oneG/C": (0.0, 0.0),
+    "init_allA/T": (0.0, 0.0),
+    "init_5T/A": (0.0, 0.0),
+    "sym": (0.0, 0.0),
+    "AA/TT": (-7.8, -22.9),       # rAA/dTT
+    "AC/TG": (-10.1, -27.7),      # rAC/dGT
+    "AG/TC": (-9.4, -26.1),       # rAG/dCT
+    "AT/TA": (-5.8, -17.4),       # rAU/dAT
+    "CA/GT": (-9.8, -27.7),       # rCA/dTG
+    "CC/GG": (-9.5, -25.1),       # rCC/dGG
+    "CG/GC": (-9.0, -24.5),       # rCG/dCG
+    "CT/GA": (-6.1, -18.4),       # rCU/dAG
+    "GA/CT": (-8.6, -22.9),       # rGA/dTC
+    "GC/CG": (-10.6, -27.7),      # rGC/dGC
+    "GG/CC": (-13.3, -35.5),      # rGG/dCC
+    "GT/CA": (-9.3, -25.5),       # rGU/dAC
+    "TA/AT": (-6.6, -19.7),       # rUA/dTA
+    "TC/AG": (-6.5, -16.4),       # rUC/dGA
+    "TG/AC": (-8.9, -23.5),       # rUG/dCA
+    "TT/AA": (-7.4, -24.5),       # rUU/dAA
+}
+
+
+@dataclass(frozen=True)
+class NNModel:
+    """A nearest-neighbor parameter set together with the salt it was measured at.
+
+    Attributes:
+        name: Stable identifier used in configs and cache keys.
+        table: Biopython-format NN dict, ``{dimer: (ΔH, ΔS)}``.
+        reference_monovalent_mM: Monovalent salt the parameters were derived at,
+            or ``None`` for the 1 M convention Biopython's salt corrections
+            assume. A number here means the correction must be applied
+            *relative* to it — see :func:`melting_temperature`.
+        citation: Where the numbers come from.
+    """
+
+    name: str
+    table: Dict[str, Tuple[float, float]]
+    reference_monovalent_mM: Optional[float]
+    citation: str
+
+
+DNA_DNA = NNModel(
+    "santalucia1998", mt.DNA_NN4, None,
+    "SantaLucia 1998 PNAS 95:1460 (unified); Allawi & SantaLucia 1997",
+)
+RNA_RNA = NNModel(
+    "freier1986", mt.RNA_NN1, None,
+    "Freier et al. 1986 PNAS 83:9373 (Xia 1998 is newer: mt.RNA_NN2)",
+)
+HYBRID_SUGIMOTO1995 = NNModel(
+    "sugimoto1995", mt.R_DNA_NN1, None,
+    "Sugimoto et al. 1995 Biochemistry 34:11211 — derived at 1 M NaCl",
+)
+HYBRID_BANERJEE2020 = NNModel(
+    "banerjee2020", R_DNA_BANERJEE2020, 100.0,
+    "Banerjee et al. 2020 NAR 48:12042, corrected NAR 2021 49:10796 — 100 mM NaCl",
+)
+
+#: Selectable DNA:RNA hybrid models. Sugimoto stays the default: it is the
+#: software default everywhere (Biopython, IDT, MELTING), so it keeps our
+#: numbers comparable with colleagues'. Banerjee is the more accurate set at
+#: physiological salt (Tm error 1.1 °C vs Sugimoto's 4.9 °C at 100 mM) and is
+#: opt-in via ReactionConditions.hybrid_nn_model.
+HYBRID_MODELS: Dict[str, NNModel] = {
+    HYBRID_SUGIMOTO1995.name: HYBRID_SUGIMOTO1995,
+    HYBRID_BANERJEE2020.name: HYBRID_BANERJEE2020,
+}
+
+DEFAULT_HYBRID_MODEL = HYBRID_SUGIMOTO1995.name
+
+#: Chemistry label -> (probe strand type, target strand type).
+CHEMISTRY_STRANDS = {
+    "drna": ("DNA", "RNA"),
+    "ilock": ("DNA", "RNA"),
+    "cdna": ("DNA", "DNA"),
+    "rna": ("RNA", "RNA"),
+}
+
+
+def nn_model_for(
+    sequence_type: str = "DNA",
+    target_type: str = "RNA",
+    hybrid_model: str = DEFAULT_HYBRID_MODEL,
+) -> NNModel:
+    """The NN model for a probe/target strand-type pair.
+
+    Args:
+        sequence_type: Probe strand, ``"DNA"`` or ``"RNA"``.
+        target_type: Target strand, ``"DNA"`` or ``"RNA"``.
+        hybrid_model: Which DNA:RNA set to use; ignored for the non-hybrid
+            combinations, which have one canonical table each.
+
+    Raises:
+        ValueError: if ``hybrid_model`` is not registered — fail fast rather
+            than silently falling back to a different set of physics.
+    """
+    if sequence_type == "DNA" and target_type == "RNA":
+        try:
+            return HYBRID_MODELS[hybrid_model]
+        except KeyError:
+            raise ValueError(
+                f"unknown hybrid_nn_model {hybrid_model!r}; "
+                f"known: {sorted(HYBRID_MODELS)}"
+            ) from None
+    if sequence_type == "RNA" and target_type == "RNA":
+        return RNA_RNA
+    return DNA_DNA
+
+
+def nn_model_for_chemistry(
+    chemistry: str, hybrid_model: str = DEFAULT_HYBRID_MODEL
+) -> NNModel:
+    """The NN model for a chemistry label (``dRNA`` / ``iLock`` / ``cDNA``)."""
+    seq_t, tgt_t = CHEMISTRY_STRANDS.get(str(chemistry).lower(), ("DNA", "RNA"))
+    return nn_model_for(seq_t, tgt_t, hybrid_model)
+
+
+def melting_temperature(seq: str, model: NNModel, reaction) -> float:
+    """Tm (°C) of ``seq`` under ``reaction``, honouring the model's salt reference.
+
+    ``seq`` must already be the strand the table expects — for a DNA:RNA hybrid
+    that is the RNA-sense strand (see ``chemistry.dna_revcomp_to_rna``).
+
+    Co-solvent depression is **not** applied here; callers apply
+    ``reaction.apply_solvents`` so the raw NN Tm stays inspectable.
+
+    For a 1 M-referenced model this is plain ``Tm_NN``. For a model measured at
+    a finite salt, the parameters already embody that condition, so the salt
+    model is used only for the shift from the reference to the actual buffer:
+    the (over-)correction from 1 M is common to both terms and cancels.
+    """
+    kwargs = reaction.tm_nn_kwargs()
+    if model.reference_monovalent_mM is None:
+        return mt.Tm_NN(seq, nn_table=model.table, **kwargs)
+
+    at_reference_salt = mt.Tm_NN(
+        seq, nn_table=model.table, **{**kwargs, "saltcorr": 0}
+    )
+    reference_kwargs = {
+        **kwargs,
+        "Na": 0.0,
+        "K": model.reference_monovalent_mM,
+        "Tris": 0.0,
+        "Mg": 0.0,
+        "dNTPs": 0.0,
+    }
+    shift = (
+        mt.Tm_NN(seq, nn_table=model.table, **kwargs)
+        - mt.Tm_NN(seq, nn_table=model.table, **reference_kwargs)
+    )
+    return at_reference_salt + shift
+
+
+__all__ = [
+    "CHEMISTRY_STRANDS",
+    "DEFAULT_HYBRID_MODEL",
+    "DNA_DNA",
+    "HYBRID_BANERJEE2020",
+    "HYBRID_MODELS",
+    "HYBRID_SUGIMOTO1995",
+    "NNModel",
+    "R_DNA_BANERJEE2020",
+    "RNA_RNA",
+    "melting_temperature",
+    "nn_model_for",
+    "nn_model_for_chemistry",
+]

--- a/probe_designer/rt_primer.py
+++ b/probe_designer/rt_primer.py
@@ -23,6 +23,7 @@ from typing import Callable, Dict, Optional
 
 from Bio.SeqUtils import MeltingTemp as mt
 
+from probe_designer.nn_tables import melting_temperature, nn_model_for
 from probe_designer.chemistry import (
     ReactionConditions,
     dna_revcomp_to_rna,
@@ -55,14 +56,15 @@ def _gc_percent(seq: str) -> float:
 def _compute_tm(primer: str, reaction: ReactionConditions) -> float:
     """Tm of a DNA RT primer annealed to its mRNA template.
 
-    The primer:template duplex is DNA:RNA, so ``R_DNA_NN1`` must be fed the RNA
-    (template) strand — the reverse complement of the primer — per Biopython's
-    convention. Salt/Mg conditions come from ``reaction``. Reverse transcription
-    carries no formamide, so the caller passes a formamide-free ReactionConditions.
+    The primer:template duplex is DNA:RNA, so the hybrid table must be fed the
+    RNA (template) strand — the reverse complement of the primer — per
+    Biopython's convention. Salt/Mg conditions and the choice of hybrid NN set
+    come from ``reaction`` (audit R6). Reverse transcription carries no
+    formamide, so the caller passes a formamide-free ReactionConditions.
     """
-    rna_template = dna_revcomp_to_rna(primer)
-    tm = mt.Tm_NN(rna_template, nn_table=mt.R_DNA_NN1, **reaction.tm_nn_kwargs())
-    return round(reaction.apply_formamide(tm), 1)
+    model = nn_model_for("DNA", "RNA", reaction.hybrid_nn_model)
+    tm = melting_temperature(dna_revcomp_to_rna(primer), model, reaction)
+    return round(reaction.apply_solvents(tm), 1)
 
 
 def _resolve_strand(strand) -> int:
@@ -292,3 +294,4 @@ def design_rt_primer_from_target(
         "gap_nt": gap, "strand": 1,
         "notes": "; ".join(notes) if notes else "",
     }
+

--- a/probe_designer/search_strategies.py
+++ b/probe_designer/search_strategies.py
@@ -7,12 +7,14 @@ import os
 import sys
 import json
 import random  # noqa: F401 (reserved for future stochastic strategies)
+import warnings
 from typing import List, Dict, Any, Tuple, Optional
 from tqdm import tqdm  # noqa: F401 (progress bars may be enabled later)
 
 from .chemistry import reverse_complement
 from .config import SearchConfig, FilterConfig
 from .filtering import SequenceFilter
+from .isoform_coverage import IsoformCoverageIndex, coding_first
 
 
 class SearchStrategy:
@@ -208,26 +210,60 @@ class ExonJunctionStrategy(SearchStrategy):
 
 class IsoformAwareStrategy(SearchStrategy):
     """Unified strategy for isoform-aware probe design.
-    
+
     Supports two modes:
     - 'specific': Design probes unique to single isoforms (uses isoforms_intersection)
-    - 'consensus': Design probes that bind as many isoforms as possible (uses isoforms_union)
+    - 'consensus': Design probes that bind every isoform whose mRNA can actually
+      be ligated across the window (see probe_designer.isoform_coverage)
     """
-    
-    def __init__(self, search_config: SearchConfig, filter_config: FilterConfig, isoforms: List[Dict], 
+
+    def __init__(self, search_config: SearchConfig, filter_config: FilterConfig, isoforms: List[Dict],
                  genome_accessor=None, mode: str = 'consensus', show_progress: bool = False):
         super().__init__(search_config, filter_config, show_progress)
         if mode not in ('specific', 'consensus'):
             raise ValueError(f"Mode must be 'specific' or 'consensus', got '{mode}'")
         self.mode = mode
-        self.isoforms = isoforms
+        # Protein-coding transcripts first: the search walks isoforms in order
+        # and the position-dedup keeps whichever reached a window first, so
+        # this decides which transcript a shipped probe is recorded against.
+        self.isoforms = coding_first(isoforms) if isoforms else isoforms
         self.genome_accessor = genome_accessor
         self.awareness = IsoformAwareness(self.isoforms, self.genome_accessor) if (self.isoforms and self.genome_accessor) else None
         if not self.awareness:
             raise ValueError(f"IsoformAwareStrategy requires isoforms and genome_accessor")
-    
+
+        self.min_isoform_arm_nt = int(getattr(search_config, 'min_isoform_arm_nt', 16))
+        self.require_protein_coding = bool(
+            getattr(search_config, 'require_protein_coding', True)
+        )
+        self.coverage_index = IsoformCoverageIndex(self.isoforms)
+        if self.mode == 'consensus':
+            half_window = search_config.binding_site_length // 2
+            if self.min_isoform_arm_nt > half_window:
+                raise ValueError(
+                    f"min_isoform_arm_nt={self.min_isoform_arm_nt} exceeds half the "
+                    f"binding site ({half_window} nt); no window could satisfy it"
+                )
+        # Warned from search_binding_sites, where the gene name is known — in a
+        # multi-gene panel an unattributed warning is not actionable.
+        self._exempt_from_protein_coding = (
+            self.mode == 'consensus'
+            and self.require_protein_coding
+            and not self.coverage_index.has_protein_coding()
+        )
+        if self._exempt_from_protein_coding:
+            self.require_protein_coding = False
+
     def search_binding_sites(self, sequence: str, gene_name: str) -> List[Dict[str, Any]]:
         """Search binding sites using isoform-aware approach."""
+        if self._exempt_from_protein_coding:
+            warnings.warn(
+                f"[{gene_name}] no protein_coding transcript in the isoform set; "
+                "require_protein_coding is ignored for this gene and its sites "
+                "are credited to non-coding transcripts only.",
+                UserWarning,
+                stacklevel=2,
+            )
         # Initialize genome sequence (may take time on first call)
         _ = self.awareness.get_genome_seq()
 
@@ -330,6 +366,7 @@ class IsoformAwareStrategy(SearchStrategy):
                         regions.extend(self.awareness.get_overlapping_regions(reg_start, reg_end))
                     
                     # Determine target isoforms based on mode
+                    coverage: Dict[str, Any] = {}
                     if self.mode == 'specific':
                         target_isoforms = self.awareness.isoforms_intersection(regions)
                         # Only proceed if this position is unique to the current isoform
@@ -340,13 +377,31 @@ class IsoformAwareStrategy(SearchStrategy):
                             continue
                         covered = target_isoforms
                     elif self.mode == 'consensus':  # consensus mode
-                        covered = set(self.awareness.isoforms_union(regions))
+                        # An isoform is credited only when a contiguous run of
+                        # its own mRNA spans the ligation junction with
+                        # min_isoform_arm_nt on each side — mere overlap, which
+                        # `isoforms_union` used to accept, is not binding.
+                        coverage = self.coverage_index.credit(
+                            target_regions, strand, self.min_isoform_arm_nt,
+                        )
+                        covered = set(coverage)
                         if not covered:
                             current_pos += 1
-                            if position_pbar: 
+                            if position_pbar:
                                 position_pbar.update(1)
                             continue
-                    
+                        # A site that binds no protein-coding transcript of its
+                        # own gene cannot report that gene's expression, however
+                        # good its thermodynamics look.
+                        if self.require_protein_coding and not any(
+                            self.coverage_index.is_productive_isoform(name)
+                            for name in covered
+                        ):
+                            current_pos += 1
+                            if position_pbar:
+                                position_pbar.update(1)
+                            continue
+
                     # Get target sequence from regions
                     target_seq = self.awareness.get_target_seq(target_regions, strand)
                     
@@ -466,8 +521,23 @@ class IsoformAwareStrategy(SearchStrategy):
                         probe_dict['isoform_overlap_num'] = len(covered)
                         probe_dict['segments'] = target_regions  # Alias for target_regions
                     else:  # consensus
-                        probe_dict['target_isoforms'] = sorted(list(covered))
+                        probe_dict['target_isoforms'] = sorted(covered)
                         probe_dict['isoform_overlap_num'] = len(covered)
+                        # Per-isoform arm geometry: how much of each arm
+                        # survives in that transcript. Full length on the host
+                        # by construction; short where an exon boundary eats
+                        # into a distal end.
+                        probe_dict['isoform_coverage'] = {
+                            name: {
+                                'arm_3prime_nt': cov.arm_3prime_nt,
+                                'arm_5prime_nt': cov.arm_5prime_nt,
+                            }
+                            for name, cov in sorted(coverage.items())
+                        }
+                        probe_dict['protein_coding_overlap_num'] = sum(
+                            1 for name in covered
+                            if self.coverage_index.is_productive_isoform(name)
+                        )
                     
                     candidates.append(probe_dict)
                     current_pos += 1

--- a/tests/unit/test_config_roundtrip.py
+++ b/tests/unit/test_config_roundtrip.py
@@ -66,6 +66,36 @@ class TestRoundTrip:
         assert expected - set(written) == set()
 
 
+class TestBufferKnobsAreReachable:
+    """Every ReactionConditions knob must be settable from a config file.
+
+    ``FilterConfig`` deliberately mirrors ``ReactionConditions`` as flat fields
+    because the generic YAML loader cannot round-trip a nested dataclass. That
+    mirror is a duplication, so it drifts: ``hybrid_nn_model`` was added to
+    ReactionConditions and was unreachable from YAML until this test existed.
+    """
+
+    def test_filter_config_exposes_every_reaction_field(self):
+        from probe_designer.chemistry import ReactionConditions
+
+        reaction_fields = {f.name for f in dataclasses.fields(ReactionConditions)}
+        filter_fields = {f.name for f in dataclasses.fields(FilterConfig)}
+        missing = reaction_fields - filter_fields
+        assert not missing, (
+            f"ReactionConditions knob(s) {sorted(missing)} cannot be set from a "
+            "config file — add the flat field to FilterConfig and forward it in "
+            "reaction_conditions()"
+        )
+
+    def test_values_actually_reach_the_reaction(self):
+        """Present-but-not-forwarded is the same bug one step later."""
+        cfg = FilterConfig(hybrid_nn_model="banerjee2020", mg_mM=4.0, lab_temp_c=42.0)
+        reaction = cfg.reaction_conditions()
+        assert reaction.hybrid_nn_model == "banerjee2020"
+        assert reaction.mg_mM == 4.0
+        assert reaction.lab_temp_c == 42.0
+
+
 class TestNoDeadKeys:
     @pytest.mark.parametrize("name", SHIPPED_CONFIGS)
     def test_shipped_yaml_filter_keys_all_map_to_a_field(self, name):

--- a/tests/unit/test_config_roundtrip.py
+++ b/tests/unit/test_config_roundtrip.py
@@ -19,7 +19,7 @@ import dataclasses
 import pytest
 import yaml
 
-from probe_designer.config import ConfigManager, FilterConfig
+from probe_designer.config import ConfigManager, FilterConfig, SearchConfig
 
 SHIPPED_CONFIGS = [
     "config_consensus.yaml",
@@ -65,6 +65,31 @@ class TestRoundTrip:
         expected = {f.name for f in dataclasses.fields(FilterConfig)}
         assert expected - set(written) == set()
 
+    def test_every_search_field_survives_save_then_load(self, tmp_path):
+        # Same hand-written-dict trap as `filter`, one section over. The
+        # isoform-crediting knobs added 2026-08-02 are safety gates: losing
+        # them on a round trip silently reverts a run to the old behaviour.
+        cm = ConfigManager()
+        cm.search.min_isoform_arm_nt = 18
+        cm.search.require_protein_coding = False
+        cm.search.binding_site_length = 36
+        cm.search.step_size = 2
+
+        out = tmp_path / "roundtrip_search.yaml"
+        cm.save_config(str(out))
+
+        restored = ConfigManager()
+        restored.load_config(str(out))
+        assert dataclasses.asdict(restored.search) == dataclasses.asdict(cm.search)
+
+    def test_saved_yaml_carries_every_search_field(self, tmp_path):
+        cm = ConfigManager()
+        out = tmp_path / "full_search.yaml"
+        cm.save_config(str(out))
+        written = yaml.safe_load(out.read_text(encoding="utf-8"))["search"]
+        expected = {f.name for f in dataclasses.fields(SearchConfig)}
+        assert expected - set(written) == set()
+
 
 class TestBufferKnobsAreReachable:
     """Every ReactionConditions knob must be settable from a config file.
@@ -108,6 +133,16 @@ class TestNoDeadKeys:
             f"loader therefore ignores: {sorted(unknown)}"
         )
 
+    @pytest.mark.parametrize("name", SHIPPED_CONFIGS)
+    def test_shipped_yaml_search_keys_all_map_to_a_field(self, name):
+        data = yaml.safe_load((_configs_dir() / name).read_text(encoding="utf-8"))
+        known = {f.name for f in dataclasses.fields(SearchConfig)}
+        unknown = set(data.get("search") or {}) - known
+        assert not unknown, (
+            f"{name} sets search keys that SearchConfig does not define and the "
+            f"loader therefore ignores: {sorted(unknown)}"
+        )
+
     def test_loader_warns_instead_of_silently_dropping(self, tmp_path):
         cfg = tmp_path / "typo.yaml"
         cfg.write_text(
@@ -115,4 +150,13 @@ class TestNoDeadKeys:
         )
         cm = ConfigManager()
         with pytest.warns(UserWarning, match="formamide_pc"):
+            cm.load_config(str(cfg))
+
+    def test_loader_warns_on_an_unknown_search_key(self, tmp_path):
+        cfg = tmp_path / "typo_search.yaml"
+        cfg.write_text(
+            yaml.safe_dump({"search": {"min_isoform_arm": 16}}), encoding="utf-8",
+        )
+        cm = ConfigManager()
+        with pytest.warns(UserWarning, match="min_isoform_arm"):
             cm.load_config(str(cfg))

--- a/tests/unit/test_isoform_consensus_credit.py
+++ b/tests/unit/test_isoform_consensus_credit.py
@@ -1,0 +1,271 @@
+"""``isoform_consensus`` crediting, end-to-end through IsoformAwareStrategy.
+
+Companion to ``test_isoform_coverage.py``, which locks the pure geometry. This
+file locks what the SEARCH STRATEGY does with it — see
+``experiments/20260727_CRC_BRAF_round1/DESIGNER_ISSUE_isoform_coverage.md``:
+
+* an isoform is credited only when the ligation junction is paired and both
+  effective arms clear ``min_isoform_arm_nt``;
+* a selected site must bind at least one protein-coding transcript, so a
+  candidate generated on a minor / non-coding isoform cannot ship on its own;
+* the isoform a candidate is BUILT on is the canonical one where there is a
+  choice, so the position-dedup keeps the protein-coding host.
+
+Synthetic locus (plus strand, 1000..1399), four transcripts:
+
+    G-201  protein_coding      [1000..1199] [1300..1399]
+    G-204  protein_coding      [1000..1100] [1150..1199] [1300..1399]
+    G-202  retained_intron     [1000..1399]                 (one long exon)
+    G-203  processed_transcript             [1200..1299]
+
+G-204's exon boundary at 1100 sits inside a 40-nt window starting at 1080 —
+the synthetic form of the real FABP1-201 straddler. 1200..1299 is intronic in
+both protein-coding transcripts — the synthetic form of the GNLY / MZB1 sites
+that bind no coding transcript at all.
+"""
+from __future__ import annotations
+
+import pytest
+
+from probe_designer.config import FilterConfig, SearchConfig
+from probe_designer.search_strategies import IsoformAwareness, IsoformAwareStrategy
+
+
+LOCUS_START, LOCUS_END = 1000, 1399
+BDS_LEN = 40
+
+
+def _iso(name, exons, biotype):
+    return {
+        "id": f"ENST_{name}",
+        "display_name": name,
+        "biotype": biotype,
+        "start": min(s for s, _ in exons),
+        "end": max(e for _, e in exons),
+        "strand": 1,
+        "seq_region_name": "chrT",
+        "Exon": [{"start": s, "end": e} for s, e in exons],
+    }
+
+
+# Deliberately minor-first: the pre-fix code took whichever isoform came first
+# as the host, so input order silently decided which transcript a shipped probe
+# was designed against.
+ISOFORMS = [
+    _iso("G-202", [(1000, 1399)], "retained_intron"),
+    _iso("G-203", [(1200, 1299)], "processed_transcript"),
+    _iso("G-201", [(1000, 1199), (1300, 1399)], "protein_coding"),
+    _iso("G-204", [(1000, 1100), (1150, 1199), (1300, 1399)], "protein_coding"),
+]
+
+NONCODING_ONLY = [ISOFORMS[0], ISOFORMS[1]]
+
+# Immune-receptor constant regions carry their own Ensembl biotypes, never
+# `protein_coding`: TRAC/TRBC1 are TR_C_gene, IGHG1 is IG_C_gene. They do code
+# for protein. The 2026-08-02 bank audit found six TRAC/TRBC1 sites flagged by
+# a rule that only looked for `protein_coding` — the rule was wrong, not the
+# sites.
+IMMUNE_RECEPTOR = [
+    _iso("TRAC-201", [(1000, 1199), (1300, 1399)], "TR_C_gene"),
+    _iso("TRAC-202", [(1200, 1299)], "processed_transcript"),
+]
+
+BIOTYPE = {iso["display_name"]: iso["biotype"] for iso in ISOFORMS}
+
+
+@pytest.fixture
+def fake_genome():
+    """400 nt of repeating ACGT — 50% GC, no homopolymers, so every window
+    clears the thermal filter and the test observes crediting alone."""
+    seq = "ACGT" * ((LOCUS_END - LOCUS_START + 1) // 4)
+
+    def accessor(region_name, start, end):
+        assert region_name == "chrT"
+        return seq[start - LOCUS_START: end - LOCUS_START + 1]
+
+    return accessor
+
+
+def _search(fake_genome, isoforms=ISOFORMS, **search_kwargs):
+    search_cfg = SearchConfig(binding_site_length=BDS_LEN, **search_kwargs)
+    strategy = IsoformAwareStrategy(
+        search_cfg, FilterConfig(), isoforms,
+        genome_accessor=fake_genome, mode="consensus",
+    )
+    return strategy.search_binding_sites("", "G")
+
+
+def _at(sites, st):
+    matches = [s for s in sites if s["st"] == st]
+    return matches[0] if matches else None
+
+
+# ---------------------------------------------------------------------------
+# The count is now bounded and means something
+# ---------------------------------------------------------------------------
+
+class TestCreditedCount:
+    def test_overlap_num_never_exceeds_the_isoform_count(self, fake_genome):
+        sites = _search(fake_genome)
+        assert sites
+        assert max(s["isoform_overlap_num"] for s in sites) <= len(ISOFORMS)
+
+    def test_overlap_num_matches_the_credited_list(self, fake_genome):
+        for site in _search(fake_genome):
+            assert site["isoform_overlap_num"] == len(site["target_isoforms"])
+
+    def test_host_isoform_is_always_credited_to_itself(self, fake_genome):
+        for site in _search(fake_genome):
+            assert site["isoform_name"] in site["target_isoforms"]
+
+
+# ---------------------------------------------------------------------------
+# The straddler — the defect that shipped
+# ---------------------------------------------------------------------------
+
+class TestBoundaryStraddler:
+    """A window at 1080..1119 covers G-204 only up to its exon end at 1100,
+    leaving 1 nt above the ligation junction. It must not be credited."""
+
+    def test_old_union_rule_credited_the_straddler(self, fake_genome):
+        # Documents the defect this file exists for: the pre-fix code took the
+        # union over every atomic splice region the window TOUCHED.
+        awareness = IsoformAwareness(ISOFORMS, fake_genome)
+        regions = awareness.get_overlapping_regions(1080, 1119)
+        assert "G-204" in awareness.isoforms_union(regions)
+
+    def test_straddler_is_no_longer_credited(self, fake_genome):
+        site = _at(_search(fake_genome), 1080)
+        assert site is not None
+        assert "G-204" not in site["target_isoforms"]
+
+    def test_isoforms_that_do_contain_the_window_are_still_credited(self, fake_genome):
+        site = _at(_search(fake_genome), 1080)
+        assert set(site["target_isoforms"]) == {"G-201", "G-202"}
+
+    def test_a_lenient_bound_lets_the_straddler_back_in(self, fake_genome):
+        # 1 nt above the junction, so only a bound of 1 or 0 admits it. Locks
+        # that the knob is what decides, not a hard-coded number.
+        site = _at(_search(fake_genome, min_isoform_arm_nt=1), 1080)
+        assert "G-204" in site["target_isoforms"]
+
+
+# ---------------------------------------------------------------------------
+# The protein-coding requirement — the 6 dead CRC sites
+# ---------------------------------------------------------------------------
+
+class TestProteinCodingRequirement:
+    """1200..1299 is intronic in both coding transcripts. Candidates there are
+    credited only to G-202 (retained intron) and G-203 (processed transcript),
+    which is the shape of GNLY|0, B2M|0, VIM|1 and MZB1|0."""
+
+    def test_site_binding_no_coding_transcript_is_dropped(self, fake_genome):
+        assert _at(_search(fake_genome), 1220) is None
+
+    def test_every_surviving_site_binds_a_coding_transcript(self, fake_genome):
+        for site in _search(fake_genome):
+            credited = site["target_isoforms"]
+            assert any(BIOTYPE[name] == "protein_coding" for name in credited)
+
+    def test_the_requirement_can_be_switched_off(self, fake_genome):
+        site = _at(_search(fake_genome, require_protein_coding=False), 1220)
+        assert site is not None
+        assert set(site["target_isoforms"]) == {"G-202", "G-203"}
+
+    def test_gene_without_any_coding_transcript_still_produces_sites(self, fake_genome):
+        # A lncRNA-only gene must not be wiped out by a requirement it can
+        # never satisfy; the run falls back and says so.
+        with pytest.warns(UserWarning, match="protein_coding"):
+            sites = _search(fake_genome, isoforms=NONCODING_ONLY)
+        assert sites
+
+    def test_immune_receptor_constant_region_counts_as_coding(self, fake_genome):
+        # TR_C_gene / IG_C_gene transcripts are productive; a TRAC probe must
+        # survive the requirement, and without a fallback warning — the gene
+        # is not exempt, it genuinely has a coding transcript.
+        import warnings as _warnings
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error", UserWarning)
+            sites = _search(fake_genome, isoforms=IMMUNE_RECEPTOR)
+        assert sites
+        assert all("TRAC-201" in s["target_isoforms"] for s in sites)
+
+    def test_immune_receptor_still_drops_its_intronic_sites(self, fake_genome):
+        # The rule must still bite: 1220..1259 lies in TRAC-201's intron and is
+        # carried only by the processed_transcript.
+        sites = _search(fake_genome, isoforms=IMMUNE_RECEPTOR)
+        assert not [s for s in sites if s["st"] == 1220]
+
+    def test_distal_shortfall_inside_the_bound_is_still_credited(self, fake_genome):
+        # 1161..1200 runs 1 nt past G-201's exon end at 1199: 20 nt below the
+        # junction, 19 above. Above the bound, so it counts — this is the
+        # tolerance the lab rule deliberately allows.
+        site = _at(_search(fake_genome), 1161)
+        assert site is not None
+        assert "G-201" in site["target_isoforms"]
+
+
+# ---------------------------------------------------------------------------
+# What the site record must carry
+# ---------------------------------------------------------------------------
+
+class TestSiteRecord:
+    def test_records_per_isoform_effective_arm_lengths(self, fake_genome):
+        site = _at(_search(fake_genome), 1080)
+        assert site["isoform_coverage"]["G-201"] == {
+            "arm_3prime_nt": 20, "arm_5prime_nt": 20,
+        }
+
+    def test_coverage_keys_match_the_credited_isoforms(self, fake_genome):
+        site = _at(_search(fake_genome), 1080)
+        assert set(site["isoform_coverage"]) == set(site["target_isoforms"])
+
+    def test_records_how_many_coding_transcripts_are_bound(self, fake_genome):
+        site = _at(_search(fake_genome), 1080)
+        assert site["protein_coding_overlap_num"] == 1
+
+    def test_record_is_json_serializable(self, fake_genome):
+        import json
+        json.dumps(_search(fake_genome))
+
+
+class TestHostIsoformChoice:
+    """Position-dedup keeps whichever isoform reached the window first, so the
+    iteration order decides which transcript a shipped probe was designed
+    against. It must be a coding one wherever there is a choice."""
+
+    def test_host_is_protein_coding_despite_minor_first_input(self, fake_genome):
+        site = _at(_search(fake_genome), 1000)
+        assert BIOTYPE[site["isoform_name"]] == "protein_coding"
+
+    def test_host_is_coding_wherever_a_coding_transcript_can_host(self, fake_genome):
+        # Only an isoform whose own exon fits the whole window can host it, so
+        # this is asserted at positions that sit inside an exon of G-201/G-204
+        # as well as inside G-202's long one.
+        sites = _search(fake_genome)
+        for st in (1000, 1060, 1120):
+            assert BIOTYPE[_at(sites, st)["isoform_name"]] == "protein_coding"
+
+    def test_a_window_only_a_minor_isoform_can_host_keeps_that_host(self, fake_genome):
+        # 1161..1200 runs past every coding exon, so G-202 is the only
+        # transcript that can generate it. Re-homing it would be a lie about
+        # where the sequence came from.
+        assert _at(_search(fake_genome), 1161)["isoform_name"] == "G-202"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class TestConfiguration:
+    def test_defaults_are_on(self):
+        cfg = SearchConfig()
+        assert cfg.min_isoform_arm_nt == 16
+        assert cfg.require_protein_coding is True
+
+    def test_bound_wider_than_half_the_window_fails_fast(self, fake_genome):
+        # 21 nt on each side of the junction is unsatisfiable for a 40-nt
+        # window — not even the host qualifies. Refuse rather than return zero
+        # sites for every gene.
+        with pytest.raises(ValueError, match="min_isoform_arm_nt"):
+            _search(fake_genome, min_isoform_arm_nt=21)

--- a/tests/unit/test_isoform_coverage.py
+++ b/tests/unit/test_isoform_coverage.py
@@ -1,0 +1,323 @@
+"""Junction-core window coverage geometry.
+
+Regression home for ``DESIGNER_ISSUE_isoform_coverage.md`` (2026-08-02).
+
+``isoform_consensus`` used to credit an isoform for merely OVERLAPPING a
+candidate window (``IsoformAwareness.isoforms_union``). Because that count is
+also the sort key, the defect did not just fail to reject bad sites — it
+PREFERRED them: a window straddling a region boundary touches more regions,
+unions more isoforms, and outranks a window sitting cleanly inside the
+canonical transcript.
+
+The lab rule an isoform must satisfy to count as targeted:
+
+    the junction-centred core of the binding site (roughly +/-16 nt around the
+    ligation junction) must be present AND contiguous in that isoform's mRNA
+
+because the ligase reads the junction, and distal-arm shortfall is tolerable
+only down to a bound (an effective arm below ~16 nt will not hold at the lab's
+37 C / 10 nM hybridization).
+
+Coordinates in ``TestRealFabp1Straddler`` are the real CRC-panel FABP1 site 0
+(``experiments/20260727_CRC_BRAF_round1/output_v2``).
+"""
+from __future__ import annotations
+
+import pytest
+
+from probe_designer.isoform_coverage import (
+    PRODUCTIVE_BIOTYPES,
+    WindowCoverage,
+    credit_isoforms,
+    is_productive,
+    window_coverage,
+)
+
+
+def _iso(name, exons, *, biotype="protein_coding", strand=1):
+    """Minimal isoform dict in the legacy Ensembl-Transcript shape."""
+    return {
+        "id": f"ENST_{name}",
+        "display_name": name,
+        "biotype": biotype,
+        "strand": strand,
+        "seq_region_name": "chrT",
+        "start": min(s for s, _ in exons),
+        "end": max(e for _, e in exons),
+        "Exon": [{"start": s, "end": e} for s, e in exons],
+    }
+
+
+# ---------------------------------------------------------------------------
+# The simple case: window entirely inside one exon
+# ---------------------------------------------------------------------------
+
+class TestWindowInsideOneExon:
+    def test_full_coverage_both_sides(self):
+        cov = window_coverage([(1000, 1039)], [(900, 1200)], strand=1)
+        assert cov.lower_nt == 20
+        assert cov.upper_nt == 20
+
+    def test_full_coverage_credits_at_default_arm(self):
+        cov = window_coverage([(1000, 1039)], [(900, 1200)], strand=1)
+        assert cov.credited(16)
+
+    def test_arms_are_full_length(self):
+        cov = window_coverage([(1000, 1039)], [(900, 1200)], strand=1)
+        assert (cov.arm_3prime_nt, cov.arm_5prime_nt) == (20, 20)
+
+    def test_window_flush_with_exon_edges_is_still_full(self):
+        cov = window_coverage([(1000, 1039)], [(1000, 1039)], strand=1)
+        assert (cov.lower_nt, cov.upper_nt) == (20, 20)
+
+
+# ---------------------------------------------------------------------------
+# The defect: an exon boundary INSIDE the window
+# ---------------------------------------------------------------------------
+
+class TestRealFabp1Straddler:
+    """FABP1 site 0 of the CRC panel, verbatim.
+
+    Window chr2:88,123,073-88,123,112 (minus strand), built on FABP1-202 where
+    it sits inside one exon. FABP1-201's exon ends at 88,123,104, so only 32 of
+    the 40 nt are contiguous in that mRNA — BLAST measured 32/40, query
+    positions 9-40. The union rule credited FABP1-201 anyway.
+    """
+
+    WINDOW = [(88123073, 88123112)]
+    FABP1_202 = [(88122982, 88123138)]                    # one exon, spans it all
+    FABP1_201 = [(88122982, 88123104), (88124000, 88124100)]  # exon ends mid-window
+
+    def test_host_isoform_is_fully_covered(self):
+        cov = window_coverage(self.WINDOW, self.FABP1_202, strand=-1)
+        assert (cov.lower_nt, cov.upper_nt) == (20, 20)
+
+    def test_straddled_isoform_loses_eight_nt(self):
+        cov = window_coverage(self.WINDOW, self.FABP1_201, strand=-1)
+        # 88123105..88123112 (8 nt) are spliced out of FABP1-201.
+        assert cov.lower_nt + cov.upper_nt == 32
+
+    def test_shortfall_lands_on_the_distal_end_of_arm5(self):
+        cov = window_coverage(self.WINDOW, self.FABP1_201, strand=-1)
+        # Minus strand: the genomic-upper half is the target's 5' half, which
+        # the probe reads with arm5. 8 nt lost there leaves arm5 at 12.
+        assert cov.arm_3prime_nt == 20
+        assert cov.arm_5prime_nt == 12
+
+    def test_straddled_isoform_is_not_credited(self):
+        cov = window_coverage(self.WINDOW, self.FABP1_201, strand=-1)
+        assert not cov.credited(16)
+
+    def test_straddled_isoform_would_pass_a_lenient_bound(self):
+        # Locks the knob's meaning: 12 nt survives a 12-nt bound, not a 16-nt one.
+        cov = window_coverage(self.WINDOW, self.FABP1_201, strand=-1)
+        assert cov.credited(12)
+
+
+class TestPlusStrandArmMapping:
+    """Same geometry, plus strand: the two arms swap sides."""
+
+    WINDOW = [(1000, 1039)]
+    CLIPPED = [(900, 1031)]  # exon ends 8 nt before the window's top
+
+    def test_minus_strand_shortfall_is_arm5(self):
+        cov = window_coverage(self.WINDOW, self.CLIPPED, strand=-1)
+        assert (cov.arm_3prime_nt, cov.arm_5prime_nt) == (20, 12)
+
+    def test_plus_strand_shortfall_is_arm3(self):
+        cov = window_coverage(self.WINDOW, self.CLIPPED, strand=1)
+        assert (cov.arm_3prime_nt, cov.arm_5prime_nt) == (12, 20)
+
+    def test_side_lengths_are_strand_independent(self):
+        plus = window_coverage(self.WINDOW, self.CLIPPED, strand=1)
+        minus = window_coverage(self.WINDOW, self.CLIPPED, strand=-1)
+        assert (plus.lower_nt, plus.upper_nt) == (minus.lower_nt, minus.upper_nt)
+
+
+class TestJunctionItselfMissing:
+    """If the ligation junction is not paired, the isoform is not bound at all."""
+
+    def test_intron_over_the_junction_gives_zero(self):
+        # Window 1000..1039; junction between 1019 and 1020. The isoform has an
+        # intron at 1015..1024, so neither side reaches the junction.
+        cov = window_coverage(
+            [(1000, 1039)], [(900, 1014), (1025, 1100)], strand=1
+        )
+        assert not cov.ligatable
+        assert (cov.lower_nt, cov.upper_nt) == (0, 0)
+
+    def test_isoform_absent_from_the_locus_gives_zero(self):
+        cov = window_coverage([(1000, 1039)], [(5000, 6000)], strand=1)
+        assert not cov.ligatable
+        assert (cov.lower_nt, cov.upper_nt) == (0, 0)
+
+    def test_run_not_containing_the_junction_is_not_counted(self):
+        # Present at 1000..1007 and 1017..1039; the junction (1019/1020) sits in
+        # the SECOND run, so only that run counts: 3 nt below, 20 above.
+        cov = window_coverage(
+            [(1000, 1039)], [(900, 1007), (1017, 1100)], strand=1
+        )
+        assert (cov.lower_nt, cov.upper_nt) == (3, 20)
+        assert not cov.credited(16)
+
+
+# ---------------------------------------------------------------------------
+# Splice junctions inside the window (contiguity, not mere presence)
+# ---------------------------------------------------------------------------
+
+class TestSplicedWindow:
+    """A window that spans a splice junction of its host.
+
+    ``find_target_region`` only ever returns a multi-segment window when the
+    host's own exon ends inside it, so the segments are contiguous in the HOST
+    mRNA by construction. Another isoform binds the same probe only when it
+    shares that exact junction.
+    """
+
+    WINDOW = [(1000, 1019), (2000, 2019)]  # 20 + 20 nt across one host intron
+
+    def test_isoform_sharing_the_junction_is_fully_covered(self):
+        cov = window_coverage(self.WINDOW, [(900, 1019), (2000, 2100)], strand=1)
+        assert (cov.lower_nt, cov.upper_nt) == (20, 20)
+
+    def test_isoform_with_a_different_acceptor_is_not_credited(self):
+        # Same donor (1019) but the acceptor is 2050, so the probe's upper half
+        # is absent from this mRNA entirely.
+        cov = window_coverage(self.WINDOW, [(900, 1019), (2050, 2100)], strand=1)
+        assert not cov.ligatable
+        assert (cov.lower_nt, cov.upper_nt) == (0, 0)
+
+    def test_retained_intron_isoform_is_not_credited(self):
+        # One long exon covering both halves AND the intron between them. Every
+        # base is PRESENT, but they are not ADJACENT in the mRNA — the intron
+        # sits in between — so the probe cannot ligate on it. This is exactly
+        # the case `isoforms_union` got wrong.
+        cov = window_coverage(self.WINDOW, [(900, 2100)], strand=1)
+        assert not cov.ligatable
+        assert (cov.lower_nt, cov.upper_nt) == (0, 0)
+        assert not cov.credited(16)
+
+    def test_unligatable_is_rejected_even_at_a_zero_bound(self):
+        # `credited` must not degenerate into "0 >= 0" when the junction is
+        # unpaired; ligatability is a separate, prior condition.
+        cov = window_coverage(self.WINDOW, [(900, 2100)], strand=1)
+        assert not cov.credited(0)
+
+    def test_genomically_adjacent_exons_stay_contiguous(self):
+        # Degenerate zero-length intron: exon ends at 1019, next starts at 1020.
+        # Contiguous in the mRNA either way.
+        cov = window_coverage([(1000, 1039)], [(900, 1019), (1020, 1100)], strand=1)
+        assert (cov.lower_nt, cov.upper_nt) == (20, 20)
+
+
+# ---------------------------------------------------------------------------
+# The bound itself
+# ---------------------------------------------------------------------------
+
+class TestMinArmBound:
+    @pytest.mark.parametrize(
+        "exon_end, expected_upper",
+        [(1035, 16), (1034, 15)],
+    )
+    def test_upper_arm_length_tracks_the_exon_end(self, exon_end, expected_upper):
+        cov = window_coverage([(1000, 1039)], [(900, exon_end)], strand=1)
+        assert cov.upper_nt == expected_upper
+
+    def test_sixteen_nt_arm_is_credited_at_the_default_bound(self):
+        cov = window_coverage([(1000, 1039)], [(900, 1035)], strand=1)
+        assert cov.credited(16)
+
+    def test_fifteen_nt_arm_is_rejected_at_the_default_bound(self):
+        cov = window_coverage([(1000, 1039)], [(900, 1034)], strand=1)
+        assert not cov.credited(16)
+
+    def test_zero_bound_accepts_anything_that_pairs_the_junction(self):
+        cov = window_coverage([(1000, 1039)], [(1019, 1020)], strand=1)
+        assert (cov.lower_nt, cov.upper_nt) == (1, 1)
+        assert cov.credited(0)
+
+
+# ---------------------------------------------------------------------------
+# credit_isoforms — the set the strategy consumes
+# ---------------------------------------------------------------------------
+
+class TestCreditIsoforms:
+    ISOFORMS = [
+        _iso("G-201", [(1000, 1199), (1300, 1399)]),                    # host
+        _iso("G-204", [(1000, 1100), (1150, 1199), (1300, 1399)]),      # boundary at 1100
+        _iso("G-202", [(1000, 1399)], biotype="retained_intron"),
+        _iso("G-203", [(1200, 1299)], biotype="processed_transcript"),
+    ]
+
+    def test_clean_window_credits_every_isoform_that_contains_it(self):
+        credited = credit_isoforms([(1000, 1039)], self.ISOFORMS, strand=1, min_arm=16)
+        assert set(credited) == {"G-201", "G-204", "G-202"}
+
+    def test_straddling_window_drops_the_boundary_isoform(self):
+        # 1080..1119 straddles G-204's exon end at 1100: 21 nt present, only
+        # 1 nt of it above the junction.
+        credited = credit_isoforms([(1080, 1119)], self.ISOFORMS, strand=1, min_arm=16)
+        assert "G-204" not in credited
+        assert set(credited) == {"G-201", "G-202"}
+
+    def test_credited_count_never_exceeds_the_isoform_count(self):
+        for start in range(1000, 1360, 40):
+            credited = credit_isoforms(
+                [(start, start + 39)], self.ISOFORMS, strand=1, min_arm=16
+            )
+            assert len(credited) <= len(self.ISOFORMS)
+
+    def test_result_carries_per_isoform_arm_lengths(self):
+        credited = credit_isoforms([(1000, 1039)], self.ISOFORMS, strand=1, min_arm=16)
+        assert isinstance(credited["G-201"], WindowCoverage)
+        assert credited["G-201"].arm_3prime_nt == 20
+
+    def test_window_in_the_hosts_intron_credits_no_coding_isoform(self):
+        # The GNLY / MZB1 shape: a site built on a minor transcript whose exon
+        # is intronic in every protein-coding transcript.
+        credited = credit_isoforms([(1230, 1269)], self.ISOFORMS, strand=1, min_arm=16)
+        assert set(credited) == {"G-202", "G-203"}
+        assert not any(
+            iso["biotype"] == "protein_coding"
+            for iso in self.ISOFORMS
+            if iso["display_name"] in credited
+        )
+
+
+# ---------------------------------------------------------------------------
+# Which biotypes count as "codes for a protein"
+# ---------------------------------------------------------------------------
+
+class TestProductiveBiotypes:
+    """`protein_coding` alone is too narrow.
+
+    Immune-receptor genes carry their own Ensembl biotypes — TRAC and TRBC1 are
+    ``TR_C_gene``, IGHG1 is ``IG_C_gene`` — and never appear as
+    ``protein_coding``. The 2026-08-02 bank audit surfaced this by flagging six
+    perfectly good TRAC/TRBC1 sites as binding no coding transcript.
+    """
+
+    def test_protein_coding_is_productive(self):
+        assert is_productive("protein_coding")
+
+    @pytest.mark.parametrize(
+        "biotype",
+        ["TR_C_gene", "TR_V_gene", "TR_J_gene", "TR_D_gene",
+         "IG_C_gene", "IG_V_gene", "IG_J_gene", "IG_D_gene"],
+    )
+    def test_immune_receptor_segments_are_productive(self, biotype):
+        assert is_productive(biotype)
+
+    @pytest.mark.parametrize(
+        "biotype",
+        ["retained_intron", "processed_transcript", "nonsense_mediated_decay",
+         "lncRNA", "protein_coding_CDS_not_defined", "IG_C_pseudogene",
+         "TR_V_pseudogene", "processed_pseudogene", ""],
+    )
+    def test_unproductive_biotypes_are_rejected(self, biotype):
+        assert not is_productive(biotype)
+
+    def test_pseudogenes_are_not_admitted_by_a_prefix_match(self):
+        # The obvious implementation — "starts with IG_ or TR_" — would let
+        # every immune pseudogene in. GENCODE has hundreds of them.
+        assert not (PRODUCTIVE_BIOTYPES & {"IG_C_pseudogene", "TR_V_pseudogene"})

--- a/tests/unit/test_mutation_pipeline.py
+++ b/tests/unit/test_mutation_pipeline.py
@@ -20,7 +20,9 @@ from probe_designer.ext.mutation.pipeline import run_mutation_pipeline
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 GENOME = REPO_ROOT / "data" / "genome" / "GRCh38.fa"
-BACKBONE = REPO_ROOT / "experiments" / "SPRINTseq_369_add_A_backbone.xlsx"
+# The backbone moved out of the experiments root when that tree was emptied
+# ("every loose file moves to its own layer"); the bank is now its only home.
+BACKBONE = REPO_ROOT / "backbones" / "SP369_add_A_v1" / "sequences.xlsx"
 BZ07_INPUT = (REPO_ROOT / "experiments" / "20260425_ZCH_BZ07_mut"
               / "input" / "BZ07_mutations.xlsx")
 

--- a/tests/unit/test_nn_tables.py
+++ b/tests/unit/test_nn_tables.py
@@ -1,0 +1,146 @@
+"""Banerjee 2020 hybrid NN parameters + the one place that picks an NN table.
+
+Audit R6. Two classes of thing are tested here, and the first matters more than
+the second: a wrong thermodynamic parameter silently produces wrong Tm for every
+probe the lab orders, so the table is validated against the paper's own internal
+relations rather than merely transcribed.
+
+1. **Table integrity** — ΔG°37 = ΔH° − 310.15·ΔS° for all 16 dimers and both
+   initiation terms (catches a transcription slip in any single number), and the
+   key set maps exactly onto Biopython's, which pins the notation conversion
+   (the paper writes both strands 5'->3'; Biopython wants the DNA strand 3'->5').
+
+2. **Salt reference** — Banerjee's parameters were measured *at* 100 mM NaCl, so
+   Biopython's 1 M-referenced salt correction must not be applied on top of them.
+"""
+from __future__ import annotations
+
+import pytest
+from Bio.SeqUtils import MeltingTemp as mt
+
+from probe_designer.chemistry import ReactionConditions
+from probe_designer.nn_tables import (
+    DEFAULT_HYBRID_MODEL,
+    HYBRID_BANERJEE2020,
+    HYBRID_SUGIMOTO1995,
+    R_DNA_BANERJEE2020,
+    melting_temperature,
+    nn_model_for,
+    nn_model_for_chemistry,
+)
+
+T37 = 310.15
+
+# (Biopython key, published ΔG°37) from Banerjee 2020 Table 2 as corrected in
+# NAR 2021 49:10796. ΔH/ΔS live in the module; ΔG is the independent check.
+PUBLISHED_DG37 = {
+    "AA/TT": -0.7, "AC/TG": -1.5, "AG/TC": -1.3, "AT/TA": -0.4,
+    "CA/GT": -1.2, "CC/GG": -1.7, "CG/GC": -1.4, "CT/GA": -0.4,
+    "GA/CT": -1.5, "GC/CG": -2.0, "GG/CC": -2.3, "GT/CA": -1.4,
+    "TA/AT": -0.5, "TC/AG": -1.4, "TG/AC": -1.6, "TT/AA": 0.2,
+    "init_G/C": 2.0, "init_A/T": 2.6,
+}
+
+ARMS = [
+    "GATGATGATGATGATGATGC", "GCTAGCTAGCTAGCTAGCTA", "ATGCATGCATGCATGCATGC",
+    "GGCCGGCCGGAAGGCCGGCC", "ATATATATATCGCGATATAT", "TTGACCAGTGCATTCGAAGT",
+]
+
+
+class TestTableIntegrity:
+    @pytest.mark.parametrize("key,dg_published", sorted(PUBLISHED_DG37.items()))
+    def test_gibbs_relation_holds(self, key, dg_published):
+        """ΔG°37 = ΔH° − T·ΔS° — catches a slip in any single transcribed value."""
+        dh, ds = R_DNA_BANERJEE2020[key]
+        assert dh - T37 * ds / 1000.0 == pytest.approx(dg_published, abs=0.02)
+
+    def test_key_set_matches_biopython_hybrid_table(self):
+        """Pins the notation conversion, not just the numbers."""
+        ours = {k for k in R_DNA_BANERJEE2020 if "/" in k and not k.startswith("init")}
+        theirs = {k for k in mt.R_DNA_NN1 if "/" in k and not k.startswith("init")}
+        assert ours == theirs
+
+    def test_uses_the_corrected_initiation_entropies(self):
+        """The 2021 correction changed these; the originals fail the Gibbs check."""
+        assert R_DNA_BANERJEE2020["init_G/C"] == (0.0, -6.4)   # not -4.9
+        assert R_DNA_BANERJEE2020["init_A/T"] == (0.0, -8.4)   # not -7.0
+
+    def test_every_dimer_is_stabilizing(self):
+        for key, (dh, ds) in R_DNA_BANERJEE2020.items():
+            if "/" in key and not key.startswith("init"):
+                assert dh < 0 and ds < 0, f"{key} is not a stabilizing NN step"
+
+
+class TestSaltReference:
+    def test_banerjee_declares_its_measurement_salt(self):
+        assert HYBRID_BANERJEE2020.reference_monovalent_mM == 100.0
+        assert HYBRID_SUGIMOTO1995.reference_monovalent_mM is None  # 1 M convention
+
+    def test_no_double_correction_at_the_reference_condition(self):
+        """At 100 mM monovalent / no Mg the parameters need no salt adjustment."""
+        reaction = ReactionConditions(
+            monovalent_mM=100.0, mg_mM=0.0, formamide_pct=0.0, saltcorr=5,
+        )
+        for arm in ARMS:
+            raw = mt.Tm_NN(arm, nn_table=R_DNA_BANERJEE2020,
+                           **{**reaction.tm_nn_kwargs(), "saltcorr": 0})
+            assert melting_temperature(arm, HYBRID_BANERJEE2020, reaction) == pytest.approx(raw, abs=0.01)
+
+    def test_disagreement_with_sugimoto_matches_the_published_magnitude(self):
+        """Banerjee reports Sugimoto errs ~4.9 C at 100 mM. Applying Biopython's
+        1 M-referenced correction on top of Banerjee's 100 mM parameters instead
+        puts them ~14.5 C apart — the bug this reference handling exists to
+        prevent, and the reason a raw table swap would have been wrong."""
+        reaction = ReactionConditions(
+            monovalent_mM=100.0, mg_mM=0.0, formamide_pct=0.0, saltcorr=5,
+        )
+        diffs = [
+            melting_temperature(a, HYBRID_BANERJEE2020, reaction)
+            - melting_temperature(a, HYBRID_SUGIMOTO1995, reaction)
+            for a in ARMS
+        ]
+        mean_diff = sum(diffs) / len(diffs)
+        assert -8.0 < mean_diff < 0.0, f"mean {mean_diff:.2f} C is not the published magnitude"
+
+    def test_added_magnesium_raises_tm_relative_to_the_reference(self):
+        """The salt model is still used — for the shift from 100 mM, not from 1 M."""
+        bare = ReactionConditions(monovalent_mM=100.0, mg_mM=0.0, formamide_pct=0.0)
+        with_mg = ReactionConditions(monovalent_mM=100.0, mg_mM=10.0, formamide_pct=0.0)
+        assert (melting_temperature(ARMS[0], HYBRID_BANERJEE2020, with_mg)
+                > melting_temperature(ARMS[0], HYBRID_BANERJEE2020, bare))
+
+
+class TestModelSelection:
+    def test_sugimoto_remains_the_default(self):
+        assert DEFAULT_HYBRID_MODEL == "sugimoto1995"
+        assert ReactionConditions().hybrid_nn_model == "sugimoto1995"
+        assert nn_model_for("DNA", "RNA").table is mt.R_DNA_NN1
+
+    @pytest.mark.parametrize("seq_t,tgt_t,expected", [
+        ("DNA", "RNA", mt.R_DNA_NN1),
+        ("DNA", "DNA", mt.DNA_NN4),
+        ("RNA", "RNA", mt.RNA_NN1),
+    ])
+    def test_strand_pair_selects_the_right_table(self, seq_t, tgt_t, expected):
+        assert nn_model_for(seq_t, tgt_t).table is expected
+
+    @pytest.mark.parametrize("chemistry,expected", [
+        ("dRNA", mt.R_DNA_NN1), ("iLock", mt.R_DNA_NN1),
+        ("cDNA", mt.DNA_NN4), ("CDNA", mt.DNA_NN4),
+    ])
+    def test_chemistry_label_selects_the_right_table(self, chemistry, expected):
+        assert nn_model_for_chemistry(chemistry).table is expected
+
+    def test_hybrid_model_is_selectable(self):
+        assert nn_model_for("DNA", "RNA", "banerjee2020").table is R_DNA_BANERJEE2020
+
+    def test_unknown_model_fails_fast(self):
+        """Never silently fall back to different physics."""
+        with pytest.raises(ValueError, match="unknown hybrid_nn_model"):
+            nn_model_for("DNA", "RNA", "sugimoto1996")
+        with pytest.raises(ValueError, match="hybrid_nn_model"):
+            ReactionConditions(hybrid_nn_model="nope")
+
+    def test_model_choice_does_not_leak_into_non_hybrid_chemistries(self):
+        """cDNA is DNA:DNA — the hybrid selection must not touch it."""
+        assert nn_model_for("DNA", "DNA", "banerjee2020").table is mt.DNA_NN4

--- a/tests/unit/test_specificity_full_length.py
+++ b/tests/unit/test_specificity_full_length.py
@@ -1,0 +1,206 @@
+"""The specificity filter must check how MUCH of the probe aligned.
+
+From ``DESIGNER_ISSUE_isoform_coverage.md`` section 5: ``_check_specificity_criteria``
+accepted a site as soon as it found a same-gene alignment with identity > 0.95,
+and never looked at the alignment length. So a probe that matches its own gene
+over only 32 of its 40 nt — the signature of a site designed on a minor isoform
+and read against the canonical transcript — passed exactly like a 40/40 one.
+That is why BLAST did not catch any of the six dead CRC sites.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from probe_designer.config import BlastConfig, FilterConfig
+from probe_designer.filtering import SequenceFilter
+
+
+PROBE = "CTCTTGAAGACAATGTCACCCAATGTCATGGTCTGAAAGC"  # real FABP1 site 0, 40 nt
+
+
+def _filter(**filter_kwargs) -> SequenceFilter:
+    cfg = FilterConfig(target_organisms=["Homo sapiens"], **filter_kwargs)
+    return SequenceFilter(cfg, BlastConfig())
+
+
+def _site(gene="FABP1", sequence=PROBE):
+    return {"gene_name": gene, "sequence": sequence}
+
+
+def _alignment(align_length, *, hit_def="Homo sapiens FABP1 mRNA", identity=1.0):
+    return {
+        "hit_id": "ENST00000393750",
+        "hit_def": hit_def,
+        "evalue": 1e-13,
+        "identity": identity,
+        "align_length": align_length,
+        "score": 80,
+        "frame": (1, -1),
+    }
+
+
+def _blast_info(*alignments):
+    return {
+        "alignments": list(alignments),
+        "evalue": 1e-13,
+        "identity": 1.0,
+        "alignment_count": len(alignments),
+    }
+
+
+class TestSameGeneCoverage:
+    def test_full_length_same_gene_hit_passes(self):
+        assert _filter()._check_specificity_criteria(
+            _blast_info(_alignment(40)), _site()
+        )
+
+    def test_partial_same_gene_hit_is_rejected(self):
+        # The FABP1-201 case: 32 of 40 nt align because the rest is spliced out.
+        assert not _filter()._check_specificity_criteria(
+            _blast_info(_alignment(32)), _site()
+        )
+
+    def test_one_full_length_hit_among_partials_is_enough(self):
+        # A probe designed on the canonical transcript legitimately gives short
+        # hits on minor isoforms; it only has to be full length SOMEWHERE.
+        assert _filter()._check_specificity_criteria(
+            _blast_info(_alignment(32), _alignment(40)), _site()
+        )
+
+    def test_one_nt_short_still_passes_the_default_tolerance(self):
+        # 39/40 = 0.975 >= the 0.95 default: BLAST routinely trims a terminal
+        # mismatch, and that is not the failure mode this gate is for.
+        assert _filter()._check_specificity_criteria(
+            _blast_info(_alignment(39)), _site()
+        )
+
+    def test_threshold_is_configurable(self):
+        assert _filter(min_same_gene_coverage=0.5)._check_specificity_criteria(
+            _blast_info(_alignment(32)), _site()
+        )
+
+    def test_alignment_without_a_length_is_not_assumed_full(self):
+        no_length = _alignment(40)
+        del no_length["align_length"]
+        assert not _filter()._check_specificity_criteria(
+            _blast_info(no_length), _site()
+        )
+
+
+class TestUnchangedRules:
+    """The length check is additive — the pre-existing rules still decide."""
+
+    def test_off_target_gene_hit_still_rejects(self):
+        off_target = _alignment(40, hit_def="Homo sapiens TLR6 mRNA")
+        assert not _filter()._check_specificity_criteria(
+            _blast_info(_alignment(40), off_target), _site()
+        )
+
+    def test_no_target_organism_hit_still_rejects(self):
+        assert not _filter()._check_specificity_criteria(
+            _blast_info(_alignment(40, hit_def="Mus musculus Fabp1 mRNA")), _site()
+        )
+
+    def test_disabling_specificity_bypasses_everything(self):
+        cfg = FilterConfig(target_organisms=["Homo sapiens"], require_specificity=False)
+        filt = SequenceFilter(cfg, BlastConfig())
+        assert filt._check_specificity_criteria(_blast_info(_alignment(32)), _site())
+
+
+# ---------------------------------------------------------------------------
+# The parser has to record the length in the first place
+# ---------------------------------------------------------------------------
+
+_BLAST_XML = """<?xml version="1.0"?>
+<BlastOutput>
+  <BlastOutput_program>blastn</BlastOutput_program>
+  <BlastOutput_version>BLASTN 2.17.0+</BlastOutput_version>
+  <BlastOutput_reference>ref</BlastOutput_reference>
+  <BlastOutput_db>human_gencode_db</BlastOutput_db>
+  <BlastOutput_query-ID>Query_1</BlastOutput_query-ID>
+  <BlastOutput_query-def>FABP1|st=88123073|en=88123112|g_content=0.20</BlastOutput_query-def>
+  <BlastOutput_query-len>40</BlastOutput_query-len>
+  <BlastOutput_param>
+    <Parameters>
+      <Parameters_expect>1000</Parameters_expect>
+      <Parameters_sc-match>1</Parameters_sc-match>
+      <Parameters_sc-mismatch>-2</Parameters_sc-mismatch>
+      <Parameters_gap-open>0</Parameters_gap-open>
+      <Parameters_gap-extend>0</Parameters_gap-extend>
+      <Parameters_filter>F</Parameters_filter>
+    </Parameters>
+  </BlastOutput_param>
+  <BlastOutput_iterations>
+    <Iteration>
+      <Iteration_iter-num>1</Iteration_iter-num>
+      <Iteration_query-ID>Query_1</Iteration_query-ID>
+      <Iteration_query-def>FABP1|st=88123073|en=88123112|g_content=0.20</Iteration_query-def>
+      <Iteration_query-len>40</Iteration_query-len>
+      <Iteration_hits>
+        <Hit>
+          <Hit_num>1</Hit_num>
+          <Hit_id>ENST00000295834</Hit_id>
+          <Hit_def>Homo sapiens FABP1-201</Hit_def>
+          <Hit_accession>ENST00000295834</Hit_accession>
+          <Hit_len>800</Hit_len>
+          <Hit_hsps>
+            <Hsp>
+              <Hsp_num>1</Hsp_num>
+              <Hsp_bit-score>64.0</Hsp_bit-score>
+              <Hsp_score>32</Hsp_score>
+              <Hsp_evalue>1e-10</Hsp_evalue>
+              <Hsp_query-from>9</Hsp_query-from>
+              <Hsp_query-to>40</Hsp_query-to>
+              <Hsp_hit-from>200</Hsp_hit-from>
+              <Hsp_hit-to>169</Hsp_hit-to>
+              <Hsp_query-frame>1</Hsp_query-frame>
+              <Hsp_hit-frame>-1</Hsp_hit-frame>
+              <Hsp_identity>32</Hsp_identity>
+              <Hsp_positive>32</Hsp_positive>
+              <Hsp_gaps>0</Hsp_gaps>
+              <Hsp_align-len>32</Hsp_align-len>
+              <Hsp_qseq>CAATGTCACCCAATGTCATGGTCTGAAAGC</Hsp_qseq>
+              <Hsp_hseq>CAATGTCACCCAATGTCATGGTCTGAAAGC</Hsp_hseq>
+              <Hsp_midline>||||||||||||||||||||||||||||||</Hsp_midline>
+            </Hsp>
+          </Hit_hsps>
+        </Hit>
+      </Iteration_hits>
+    </Iteration>
+  </BlastOutput_iterations>
+</BlastOutput>
+"""
+
+
+class TestParserRecordsAlignLength:
+    def test_align_length_survives_the_xml_parse(self, tmp_path: Path):
+        xml = tmp_path / "blast_results.xml"
+        xml.write_text(_BLAST_XML, encoding="utf-8")
+
+        parsed = _filter()._parse_single_batch_file(str(xml), 1)
+
+        (info,) = parsed.values()
+        assert info["alignments"][0]["align_length"] == 32
+
+    def test_query_length_is_recorded_too(self, tmp_path: Path):
+        # Needed to express coverage as a fraction without trusting the caller
+        # to hand back the same sequence that was submitted.
+        xml = tmp_path / "blast_results.xml"
+        xml.write_text(_BLAST_XML, encoding="utf-8")
+
+        parsed = _filter()._parse_single_batch_file(str(xml), 1)
+
+        (info,) = parsed.values()
+        assert info["query_length"] == 40
+
+    def test_a_real_partial_hit_is_then_rejected(self, tmp_path: Path):
+        # End to end: parse -> criteria. 32/40 on its own gene must not pass.
+        xml = tmp_path / "blast_results.xml"
+        xml.write_text(_BLAST_XML, encoding="utf-8")
+
+        filt = _filter()
+        (info,) = filt._parse_single_batch_file(str(xml), 1).values()
+
+        assert not filt._check_specificity_criteria(info, _site())

--- a/tests/unit/test_tcr_pipeline.py
+++ b/tests/unit/test_tcr_pipeline.py
@@ -16,7 +16,9 @@ from probe_designer.ext.tcr.pipeline import run_tcr_pipeline
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-BACKBONE = REPO_ROOT / "experiments" / "SPRINTseq_369_add_A_backbone.xlsx"
+# The backbone moved out of the experiments root when that tree was emptied
+# ("every loose file moves to its own layer"); the bank is now its only home.
+BACKBONE = REPO_ROOT / "backbones" / "SP369_add_A_v1" / "sequences.xlsx"
 BZ23_TCR_INPUT = (
     REPO_ROOT / "experiments" / "20260418_ZCH_BZ23_TCR"
     / "input" / "BZ23_tcr_clones.xlsx"


### PR DESCRIPTION
## Summary

**Phase 4** — the last audit item, **R6**: Banerjee 2020 as a selectable
physiological-salt DNA:RNA parameter set. Sugimoto 1995 stays the default.

> **Stacked on #8** (`feature/phase3-audit-cleanups`). Review this diff alone;
> retarget to `main` once #6/#7/#8 merge.

## The table is validated, not transcribed

A wrong thermodynamic parameter silently produces wrong Tm for every probe the
lab orders, so this got checked rather than pasted. Two things had to be right,
and I got the second one wrong at first:

**1. Use the corrected table.** There is a **2021 correction** (*NAR* 49:10796)
to Banerjee 2020's Table 2: the ΔS values had been derived from ΔG°37 rounded to
one decimal. It moves the **initiation entropies materially** (−4.9 → −6.4,
−7.0 → −8.4). The original values fail ΔG°37 = ΔH° − *T*·ΔS°; the corrected ones
hold to 0.015 kcal/mol. Tests enforce that relation per entry, so a transcription
slip in any single number fails the build.

**2. Do not double-correct the salt.** Biopython's salt corrections assume
1 M-derived parameters and correct *downward*. Banerjee's already embody 100 mM
NaCl. Applying the correction on top measured **−14.5 °C** on real 20-mer arms —
against the **≈ −4.1 °C** the two models genuinely differ by, which is exactly
what the paper's own "Sugimoto errs 4.9 °C at 100 mM" claim predicts. That gap is
how the bug was caught: the first implementation looked plausible and was wrong.

`NNModel` therefore carries `reference_monovalent_mM`, and
`nn_tables.melting_temperature` uses the salt model only for the *shift* from
that reference to the actual buffer — the 1 M over-correction is common to both
terms and cancels. A raw table swap would have shipped the −14.5 °C error.

Notation is also pinned by test: Banerjee writes both strands 5'→3' (`rAC/dGT`);
Biopython keys are RNA 5'→3' (U as T) over the complement read 3'→5', so the DNA
dimer reverses (`rAC/dGT` → `"AC/TG"`). The mapped key set must equal Biopython's.

## Consolidating the table choice was required, not cosmetic

The chemistry → NN-table decision was written out in **four** modules
(`filtering`, `filtering.thermo_profile`, `ext/tcr/probe`, `rt_primer`). Adding a
second hybrid model to only some of them would have meant a config saying
`banerjee2020` while TCR and the RT primer quietly stayed on Sugimoto — the exact
drift bug this whole audit has been about. All four now resolve through
`nn_tables.nn_model_for`, verified end to end:

```
thermo_profile   sugimoto=  41.59  banerjee=  47.54  OK
ext/tcr/probe    sugimoto=  41.59  banerjee=  47.54  OK
rt_primer        sugimoto=  49.40  banerjee=  55.20  OK
cDNA (DNA:DNA)   identical under both models        OK
```

## One more instance of the mirror drifting

`FilterConfig` mirrors `ReactionConditions` as flat fields because the generic
YAML loader can't round-trip a nested dataclass. That mirror drifted **within
this commit**: `hybrid_nn_model` was added to `ReactionConditions` and was
unreachable from YAML until a new test asserted that *every* `ReactionConditions`
field is settable from a config file. The test is the point; the field is the
symptom.

## Reviewer note

Mean disagreement with Sugimoto is ≈ −4 °C, but **per arm it spans roughly
−13 to +6 °C** — the two studies distribute stability differently across dimers.
Switching models therefore **re-ranks** candidates rather than offsetting them.
That is why Sugimoto remains the default and this is an explicit opt-in, and why
you should not switch an in-flight panel mid-design.

## Testing

`python -m pytest` → **674 passed, 1 skipped**. `tests/unit/test_nn_tables.py`
covers table integrity (Gibbs relation per entry, key-set mapping, corrected
initiation entropies), the salt reference (no double correction at the reference
condition, published-magnitude disagreement, Mg still raising Tm), and model
selection (default unchanged, fail-fast on an unknown name, no leakage into
non-hybrid chemistries).

## Usage

```yaml
filter:
  hybrid_nn_model: banerjee2020   # default: sugimoto1995
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
